### PR TITLE
Adds the query parameter to the guzzle call for GET requests.

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -35,7 +35,7 @@ interface Adapter
      *
      * @return mixed
      */
-    public function get(String $uri, array $headers): ResponseInterface;
+    public function get(String $uri, array $query, array $headers): ResponseInterface;
 
     /**
      * @param String $uri

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -38,9 +38,9 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function get(String $uri, array $headers = array()): ResponseInterface
+    public function get(String $uri, array $query = array(), array $headers = array()): ResponseInterface
     {
-        $response = $this->client->get($uri, ['headers' => $headers]);
+        $response = $this->client->get($uri, ['query' => $query, 'headers' => $headers]);
 
         $this->checkError($response);
         return $response;

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -60,35 +60,33 @@ class DNS implements API
         string $direction = "",
         string $match = "all"
     ): \stdClass {
-        $options = [
+        $query = [
             'page' => $page,
             'per_page' => $perPage,
             'match' => $match
         ];
 
         if (!empty($type)) {
-            $options['type'] = $type;
+            $query['type'] = $type;
         }
 
         if (!empty($name)) {
-            $options['name'] = $name;
+            $query['name'] = $name;
         }
 
         if (!empty($content)) {
-            $options['content'] = $content;
+            $query['content'] = $content;
         }
 
         if (!empty($order)) {
-            $options['order'] = $order;
+            $query['order'] = $order;
         }
 
         if (!empty($direction)) {
-            $options['direction'] = $direction;
+            $query['direction'] = $direction;
         }
 
-        $query = http_build_query($options);
-
-        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records?' . $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records', $query, []);
         $body = json_decode($user->getBody());
 
         $result = new \stdClass();
@@ -100,7 +98,7 @@ class DNS implements API
 
     public function getRecordDetails(string $zoneID, string $recordID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records/' . $recordID, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records/' . $recordID, [], []);
         $body = json_decode($user->getBody());
         return $body->result;
     }

--- a/src/Endpoints/IPs.php
+++ b/src/Endpoints/IPs.php
@@ -21,7 +21,7 @@ class IPs implements API
     }
 
     public function listIPs(): \stdClass {
-        $ips = $this->adapter->get('ips', []);
+        $ips = $this->adapter->get('ips', [], []);
         $body = json_decode($ips->getBody());
 
         return $body->result;

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -77,16 +77,14 @@ class PageRules implements API
             throw new EndpointException('Match can only be any or all.');
         }
 
-        $options = [
+        $query = [
             'status' => $status,
             'order' => $order,
             'direction' => $direction,
             'match' => $match
         ];
 
-        $query = http_build_query($options);
-
-        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules?' . $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules', $query, []);
         $body = json_decode($user->getBody());
 
         $result = new \stdClass();
@@ -98,7 +96,7 @@ class PageRules implements API
 
     public function getPageRuleDetails(string $zoneID, string $ruleID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules/' . $ruleID, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules/' . $ruleID, [], []);
         $body = json_decode($user->getBody());
         return $body->result;
     }

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -24,14 +24,12 @@ class UARules implements API
         int $page = 1,
         int $perPage = 20
     ): \stdClass {
-        $options = [
+        $query = [
             'page' => $page,
             'per_page' => $perPage
         ];
 
-        $query = http_build_query($options);
-
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules?' . $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules', $query, []);
         $body = json_decode($user->getBody());
 
         $result = new \stdClass();

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -21,7 +21,7 @@ class User implements API
 
     public function getUserDetails(): \stdClass
     {
-        $user = $this->adapter->get('user', []);
+        $user = $this->adapter->get('user', [], []);
         $body = json_decode($user->getBody());
         return $body->result;
     }

--- a/src/Endpoints/ZoneLockdown.php
+++ b/src/Endpoints/ZoneLockdown.php
@@ -24,14 +24,12 @@ class ZoneLockdown implements API
         int $page = 1,
         int $perPage = 20
     ): \stdClass {
-        $options = [
+        $query = [
             'page' => $page,
             'per_page' => $perPage
         ];
 
-        $query = http_build_query($options);
-
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns?' . $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns', $query, []);
         $body = json_decode($user->getBody());
 
         $result = new \stdClass();
@@ -75,7 +73,7 @@ class ZoneLockdown implements API
 
     public function getLockdownDetails(string $zoneID, string $lockdownID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, [], []);
         $body = json_decode($user->getBody());
         return $body->result;
     }

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -58,31 +58,29 @@ class Zones implements API
         string $direction = "",
         string $match = "all"
     ): \stdClass {
-        $options = [
+        $query = [
             'page' => $page,
             'per_page' => $perPage,
             'match' => $match
         ];
 
         if (!empty($name)) {
-            $options['name'] = $name;
+            $query['name'] = $name;
         }
 
         if (!empty($status)) {
-            $options['status'] = $status;
+            $query['status'] = $status;
         }
 
         if (!empty($order)) {
-            $options['order'] = $order;
+            $query['order'] = $order;
         }
 
         if (!empty($direction)) {
-            $options['direction'] = $direction;
+            $query['direction'] = $direction;
         }
 
-        $query = http_build_query($options);
-
-        $user = $this->adapter->get('zones?' . $query, []);
+        $user = $this->adapter->get('zones', $query, []);
         $body = json_decode($user->getBody());
 
         $result = new \stdClass();

--- a/tests/Adapter/GuzzleTest.php
+++ b/tests/Adapter/GuzzleTest.php
@@ -34,7 +34,7 @@ class GuzzleTest extends PHPUnit_Framework_TestCase
         $body = json_decode($response->getBody());
         $this->assertEquals("Test", $body->headers->{"X-Testing"});
 
-        $response = $this->client->get('https://httpbin.org/get', ['X-Another-Test' => 'Test2']);
+        $response = $this->client->get('https://httpbin.org/get', [], ['X-Another-Test' => 'Test2']);
         $body = json_decode($response->getBody());
         $this->assertEquals("Test2", $body->headers->{"X-Another-Test"});
     }

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -88,8 +88,17 @@ class DNSTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records?page=1&per_page=20&match=all&type=A&name=example.com&content=127.0.0.1&order=type&direction=desc'),
-                $this->equalTo([])
+            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records'),
+              $this->equalTo([
+                'page' => 1,
+                'per_page' => 20,
+                'match' => 'all',
+                'type' => 'A',
+                'name' => 'example.com',
+                'content' => '127.0.0.1',
+                'order' => 'type',
+                'direction' => 'desc']),
+              $this->equalTo([])
             );
 
         $zones = new \Cloudflare\API\Endpoints\DNS($mock);

--- a/tests/Endpoints/PageRulesTest.php
+++ b/tests/Endpoints/PageRulesTest.php
@@ -116,7 +116,14 @@ class PageRulesTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules?status=active&order=status&direction=desc&match=all'), $this->equalTo([])
+            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules'),
+              $this->equalTo([
+                'status' => 'active',
+                'order' => 'status',
+                'direction' => 'desc',
+                'match' => 'all'
+              ]),
+              $this->equalTo([])
             );
 
         $pr = new \Cloudflare\API\Endpoints\PageRules($mock);

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -45,8 +45,12 @@ class UARulesTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules?page=1&per_page=20'),
-                $this->equalTo([])
+            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules'),
+              $this->equalTo([
+                'page' => 1,
+                'per_page' => 20
+              ]),
+              $this->equalTo([])
             );
 
         $zones = new \Cloudflare\API\Endpoints\UARules($mock);

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -43,8 +43,12 @@ class ZoneLockdownTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns?page=1&per_page=20'),
-                $this->equalTo([])
+            ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns'),
+              $this->equalTo([
+                'page' => 1,
+                'per_page' => 20,
+              ]),
+              $this->equalTo([])
             );
 
         $zones = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -196,7 +196,16 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones?page=1&per_page=20&match=all&name=example.com&status=active&order=status&direction=desc'),
+            ->with($this->equalTo('zones'),
+              $this->equalTo([
+                'page' => 1,
+                'per_page' => 20,
+                'match' => 'all',
+                'name' => 'example.com',
+                'status' => 'active',
+                'order' => 'status',
+                'direction' => 'desc'
+              ]),
                 $this->equalTo([])
             );
 
@@ -280,8 +289,14 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
         $mock->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('zones?page=1&per_page=20&match=all&name=example.com'),
-                $this->equalTo([])
+            ->with($this->equalTo('zones'),
+              $this->equalTo([
+                'page' => 1,
+                'per_page' => 20,
+                'match' => 'all',
+                'name' => 'example.com',
+                ]),
+              $this->equalTo([])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);


### PR DESCRIPTION
Without this, any GET request is not able to pass optional parameters. The following snippet, for example, would continue to use default parameters without this patch.

```
$dns->listRecords($zoneID', '', '', 2, 40);
```