### PR TITLE
Remove leading namespace slashes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Note that this repository is currently under development, additional classes and
 ## Getting Started
 
 ```php
-$key     = new \Cloudflare\API\Auth\APIKey('user@example.com', 'apiKey');
+$key     = new Cloudflare\API\Auth\APIKey('user@example.com', 'apiKey');
 $adapter = new Cloudflare\API\Adapter\Guzzle($key);
-$user    = new \Cloudflare\API\Endpoints\User($adapter);
+$user    = new Cloudflare\API\Endpoints\User($adapter);
     
 echo $user->getUserID();
 ```


### PR DESCRIPTION
This makes it consistent with the middle line and is nicer to read.