### PR TITLE
Moved JSON API Responses to test fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
     "psr-4": {
       "Cloudflare\\API\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "classmap": [
+        "tests/"
+    ]
   }
 }

--- a/tests/Adapter/GuzzleTest.php
+++ b/tests/Adapter/GuzzleTest.php
@@ -8,7 +8,7 @@
 
 use GuzzleHttp\Psr7\Response;
 
-class GuzzleTest extends PHPUnit_Framework_TestCase
+class GuzzleTest extends TestCase
 {
     private $client;
 

--- a/tests/Auth/APIKeyTest.php
+++ b/tests/Auth/APIKeyTest.php
@@ -5,7 +5,7 @@
  * Date: 13/01/2017
  * Time: 17:15
  */
-class APIKeyTest extends PHPUnit_Framework_TestCase
+class APIKeyTest extends TestCase
 {
     public function testGetHeaders()
     {

--- a/tests/Auth/NoneTest.php
+++ b/tests/Auth/NoneTest.php
@@ -8,7 +8,7 @@
 
 use Cloudflare\API\Auth\None;
 
-class NoneTest extends PHPUnit_Framework_TestCase
+class NoneTest extends TestCase
 {
     public function testGetHeaders()
     {

--- a/tests/Auth/UserServiceKeyTest.php
+++ b/tests/Auth/UserServiceKeyTest.php
@@ -5,7 +5,7 @@
  * Date: 13/01/2017
  * Time: 18:03
  */
-class UserServiceKeyTest extends PHPUnit_Framework_TestCase
+class UserServiceKeyTest extends TestCase
 {
     public function testGetHeaders()
     {

--- a/tests/Configurations/ConfigurationsUARulesTest.php
+++ b/tests/Configurations/ConfigurationsUARulesTest.php
@@ -6,7 +6,7 @@
  * Date: 19/09/2017
  * Time: 15:24
  */
-class ConfigurationsUARulesTest extends PHPUnit_Framework_TestCase
+class ConfigurationsUARulesTest extends TestCase
 {
     public function testGetArray()
     {

--- a/tests/Configurations/PageRulesTargetTest.php
+++ b/tests/Configurations/PageRulesTargetTest.php
@@ -8,7 +8,7 @@
 
 use Cloudflare\API\Configurations\PageRulesTargets;
 
-class PageRulesTargetTest extends PHPUnit_Framework_TestCase
+class PageRulesTargetTest extends TestCase
 {
     public function testGetArray()
     {

--- a/tests/Configurations/ZoneLockdownTest.php
+++ b/tests/Configurations/ZoneLockdownTest.php
@@ -6,7 +6,7 @@
  * Date: 05/09/2017
  * Time: 13:50
  */
-class ConfigurationZoneLockdownTest extends PHPUnit_Framework_TestCase
+class ConfigurationZoneLockdownTest extends TestCase
 {
     public function testGetArray()
     {

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -6,32 +6,12 @@
  * Date: 09/06/2017
  * Time: 15:31
  */
-class DNSTest extends PHPUnit_Framework_TestCase
+class DNSTest extends TestCase
 {
     public function testAddRecord()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "type": "A",
-    "name": "example.com",
-    "content": "1.2.3.4",
-    "proxiable": true,
-    "proxied": false,
-    "ttl": 120,
-    "locked": false,
-    "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
-    "zone_name": "example.com",
-    "created_on": "2014-01-01T05:20:00.12345Z",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "data": {}
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/addRecord.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -55,36 +35,8 @@ class DNSTest extends PHPUnit_Framework_TestCase
 
     public function testListRecords()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": [
-    {
-      "id": "372e67954025e0ba6aaa6d586b9e0b59",
-      "type": "A",
-      "name": "example.com",
-      "content": "1.2.3.4",
-      "proxiable": true,
-      "proxied": false,
-      "ttl": 120,
-      "locked": false,
-      "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
-      "zone_name": "example.com",
-      "created_on": "2014-01-01T05:20:00.12345Z",
-      "modified_on": "2014-01-01T05:20:00.12345Z",
-      "data": {}
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listRecords.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -114,30 +66,10 @@ class DNSTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result->result_info->page);
     }
 
-    public function testGetRecordDetails()
+    public function testGetDNSRecordDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "type": "A",
-    "name": "example.com",
-    "content": "1.2.3.4",
-    "proxiable": true,
-    "proxied": false,
-    "ttl": 120,
-    "locked": false,
-    "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
-    "zone_name": "example.com",
-    "created_on": "2014-01-01T05:20:00.12345Z",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "data": {}
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getDNSRecordDetails.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 

--- a/tests/Endpoints/IPsTest.php
+++ b/tests/Endpoints/IPsTest.php
@@ -8,25 +8,12 @@
 
 use Cloudflare\API\Endpoints\IPs;
 
-class IPsTest extends PHPUnit_Framework_TestCase
+class IPsTest extends TestCase
 {
     public function testListIPs()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "ipv4_cidrs": [
-      "199.27.128.0/21"
-    ],
-    "ipv6_cidrs": [
-      "2400:cb00::/32"
-    ]
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listIPs.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 

--- a/tests/Endpoints/PageRulesTest.php
+++ b/tests/Endpoints/PageRulesTest.php
@@ -8,46 +8,16 @@
 
 use Cloudflare\API\Adapter\PageRules;
 
-class PageRulesTest extends PHPUnit_Framework_TestCase
+class PageRulesTest extends TestCase
 {
     public function testCreatePageRule()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "9a7806061c88ada191ed06f989cc3dac",
-    "targets": [
-      {
-        "target": "url",
-        "constraint": {
-          "operator": "matches",
-          "value": "*example.com/images/*"
-        }
-      }
-    ],
-    "actions": [
-      {
-        "id": "always_online",
-        "value": "on"
-      }
-    ],
-    "priority": 1,
-    "status": "active",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "created_on": "2014-01-01T05:20:00.12345Z"
-  }
-}');
         $target = new \Cloudflare\API\Configurations\PageRulesTargets('*example.com/images/*');
         $action = new \Cloudflare\API\Configurations\PageRulesActions();
         $action->setAlwaysOnline(true);
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createPageRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -72,47 +42,8 @@ class PageRulesTest extends PHPUnit_Framework_TestCase
 
     public function testListPageRules()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": [
-    {
-      "id": "9a7806061c88ada191ed06f989cc3dac",
-      "targets": [
-        {
-          "target": "url",
-          "constraint": {
-            "operator": "matches",
-            "value": "*example.com/images/*"
-          }
-        }
-      ],
-      "actions": [
-        {
-          "id": "always_online",
-          "value": "on"
-        }
-      ],
-      "priority": 1,
-      "status": "active",
-      "modified_on": "2014-01-01T05:20:00.12345Z",
-      "created_on": "2014-01-01T05:20:00.12345Z"
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listPageRules.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -135,39 +66,8 @@ class PageRulesTest extends PHPUnit_Framework_TestCase
 
     public function testGetPageRuleDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "9a7806061c88ada191ed06f989cc3dac",
-    "targets": [
-      {
-        "target": "url",
-        "constraint": {
-          "operator": "matches",
-          "value": "*example.com/images/*"
-        }
-      }
-    ],
-    "actions": [
-      {
-        "id": "always_online",
-        "value": "on"
-      }
-    ],
-    "priority": 1,
-    "status": "active",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "created_on": "2014-01-01T05:20:00.12345Z"
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getPageRuleDetails.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -184,42 +84,12 @@ class PageRulesTest extends PHPUnit_Framework_TestCase
 
     public function testUpdatePageRule()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "9a7806061c88ada191ed06f989cc3dac",
-    "targets": [
-      {
-        "target": "url",
-        "constraint": {
-          "operator": "matches",
-          "value": "*example.com/images/*"
-        }
-      }
-    ],
-    "actions": [
-      {
-        "id": "always_online",
-        "value": "on"
-      }
-    ],
-    "priority": 1,
-    "status": "active",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "created_on": "2014-01-01T05:20:00.12345Z"
-  }
-}');
         $target = new \Cloudflare\API\Configurations\PageRulesTargets('*example.com/images/*');
         $action = new \Cloudflare\API\Configurations\PageRulesActions();
         $action->setAlwaysOnline(true);
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updatePageRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('patch')->willReturn($response);
 
@@ -244,20 +114,8 @@ class PageRulesTest extends PHPUnit_Framework_TestCase
 
     public function testDeletePageRule()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "9a7806061c88ada191ed06f989cc3dac"
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/deletePageRule.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('delete')->willReturn($response);
 

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -8,38 +8,12 @@
 
 use Cloudflare\API\Endpoints\UARules;
 
-class UARulesTest extends PHPUnit_Framework_TestCase
+class UARulesTest extends TestCase
 {
     public function testListRules()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": [
-    {
-      "id": "372e67954025e0ba6aaa6d586b9e0b59",
-      "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
-      "mode": "js_challenge",
-      "configuration": {
-        "target": "ua",
-        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
-      }
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listRules.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -69,26 +43,8 @@ class UARulesTest extends PHPUnit_Framework_TestCase
         $config = new \Cloudflare\API\Configurations\UARules();
         $config->addUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4');
 
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
-    "mode": "js_challenge",
-    "configuration": {
-      "target": "ua",
-      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
-    }
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -117,26 +73,8 @@ class UARulesTest extends PHPUnit_Framework_TestCase
 
     public function getRuleDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
-    "mode": "js_challenge",
-    "configuration": {
-      "target": "ua",
-      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
-    }
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getRuleDetails.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -158,26 +96,8 @@ class UARulesTest extends PHPUnit_Framework_TestCase
         $config = new \Cloudflare\API\Configurations\UARules();
         $config->addUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4');
 
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
-    "mode": "js_challenge",
-    "configuration": {
-      "target": "ua",
-      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
-    }
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('put')->willReturn($response);
 
@@ -206,19 +126,8 @@ class UARulesTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteRule()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59"
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/deleteRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('delete')->willReturn($response);
 

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -5,30 +5,12 @@
  * Date: 01/02/2017
  * Time: 12:50
  */
-class UserTest extends PHPUnit_Framework_TestCase
+class UserTest extends TestCase
 {
     public function testGetUserDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "7c5dae5552338874e5053f2534d2767a",
-    "email": "user@example.com",
-    "first_name": "John",
-    "last_name": "Appleseed",
-    "username": "cfuser12345",
-    "telephone": "+1 123-123-1234",
-    "country": "US",
-    "zipcode": "12345",
-    "created_on": "2014-01-01T05:20:00Z",
-    "modified_on": "2014-01-01T05:20:00Z",
-    "two_factor_authentication_enabled": false
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getUserDetails.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -43,26 +25,8 @@ class UserTest extends PHPUnit_Framework_TestCase
 
     public function testGetUserID()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "7c5dae5552338874e5053f2534d2767a",
-    "email": "user@example.com",
-    "first_name": "John",
-    "last_name": "Appleseed",
-    "username": "cfuser12345",
-    "telephone": "+1 123-123-1234",
-    "country": "US",
-    "zipcode": "12345",
-    "created_on": "2014-01-01T05:20:00Z",
-    "modified_on": "2014-01-01T05:20:00Z",
-    "two_factor_authentication_enabled": false
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getUserId.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -72,26 +36,8 @@ class UserTest extends PHPUnit_Framework_TestCase
 
     public function testGetUserEmail()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "7c5dae5552338874e5053f2534d2767a",
-    "email": "user@example.com",
-    "first_name": "John",
-    "last_name": "Appleseed",
-    "username": "cfuser12345",
-    "telephone": "+1 123-123-1234",
-    "country": "US",
-    "zipcode": "12345",
-    "created_on": "2014-01-01T05:20:00Z",
-    "modified_on": "2014-01-01T05:20:00Z",
-    "two_factor_authentication_enabled": false
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getUserEmail.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -103,26 +49,8 @@ class UserTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateUserDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "7c5dae5552338874e5053f2534d2767a",
-    "email": "user@example.com",
-    "first_name": "John",
-    "last_name": "Appleseed",
-    "username": "cfuser12345",
-    "telephone": "+1 123-123-1234",
-    "country": "US",
-    "zipcode": "12345",
-    "created_on": "2014-01-01T05:20:00Z",
-    "modified_on": "2014-01-01T05:20:00Z",
-    "two_factor_authentication_enabled": false
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateUserDetails.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('patch')->willReturn($response);
 

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -6,38 +6,12 @@
  * Date: 04/09/2017
  * Time: 21:23
  */
-class ZoneLockdownTest extends PHPUnit_Framework_TestCase
+class ZoneLockdownTest extends TestCase
 {
     public function testListLockdowns()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": [
-    {
-      "id": "372e67954025e0ba6aaa6d586b9e0b59",
-      "description": "Restrict access to these endpoints to requests from a known IP address",
-      "urls": [
-        "api.mysite.com/some/endpoint*"
-      ],
-      "configurations": [
-        {
-          "target": "ip",
-          "value": "1.2.3.4"
-        }
-      ]
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listLockdowns.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -67,26 +41,8 @@ class ZoneLockdownTest extends PHPUnit_Framework_TestCase
         $config = new \Cloudflare\API\Configurations\ZoneLockdown();
         $config->addIP('1.2.3.4');
 
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Restrict access to these endpoints to requests from a known IP address",
-    "urls": [
-      "api.mysite.com/some/endpoint*"
-    ],
-    "configurations": [
-      {
-        "target": "ip",
-        "value": "1.2.3.4"
-      }
-    ]
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/addLockdown.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -115,30 +71,8 @@ class ZoneLockdownTest extends PHPUnit_Framework_TestCase
 
     public function testGetRecordDetails()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Restrict access to these endpoints to requests from a known IP address",
-    "urls": [
-      "api.mysite.com/some/endpoint*"
-    ],
-    "configurations": [
-      {
-        "target": "ip",
-        "value": "1.2.3.4"
-      }
-    ]
-  }
-}');
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getRecordDetails.json');
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -160,30 +94,8 @@ class ZoneLockdownTest extends PHPUnit_Framework_TestCase
         $config = new \Cloudflare\API\Configurations\ZoneLockdown();
         $config->addIP('1.2.3.4');
 
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59",
-    "description": "Restrict access to these endpoints to requests from a known IP address",
-    "urls": [
-      "api.mysite.com/some/endpoint*"
-    ],
-    "configurations": [
-      {
-        "target": "ip",
-        "value": "1.2.3.4"
-      }
-    ]
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateLockdown.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('put')->willReturn($response);
 
@@ -215,20 +127,8 @@ class ZoneLockdownTest extends PHPUnit_Framework_TestCase
         $config = new \Cloudflare\API\Configurations\ZoneLockdown();
         $config->addIP('1.2.3.4');
 
-        $stream = GuzzleHttp\Psr7\stream_for('
-{
-  "success": true,
-  "errors": [
-    {}
-  ],
-  "messages": [
-    {}
-  ],
-  "result": {
-    "id": "372e67954025e0ba6aaa6d586b9e0b59"
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/deleteLockdown.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('delete')->willReturn($response);
 

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -6,65 +6,12 @@
  * Date: 06/06/2017
  * Time: 16:01
  */
-class ZonesTest extends PHPUnit_Framework_TestCase
+class ZonesTest extends TestCase
 {
     public function testAddZone()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "023e105f4ecef8ad9ca31a8372d0c353",
-    "name": "example.com",
-    "development_mode": 7200,
-    "original_name_servers": [
-      "ns1.originaldnshost.com",
-      "ns2.originaldnshost.com"
-    ],
-    "original_registrar": "GoDaddy",
-    "original_dnshost": "NameCheap",
-    "created_on": "2014-01-01T05:20:00.12345Z",
-    "modified_on": "2014-01-01T05:20:00.12345Z",
-    "name_servers": [
-      "tony.ns.cloudflare.com",
-      "woz.ns.cloudflare.com"
-    ],
-    "owner": {
-      "id": "7c5dae5552338874e5053f2534d2767a",
-      "email": "user@example.com",
-      "owner_type": "user"
-    },
-    "permissions": [
-      "#zone:read",
-      "#zone:edit"
-    ],
-    "plan": {
-      "id": "e592fd9519420ba7405e1307bff33214",
-      "name": "Pro Plan",
-      "price": 20,
-      "currency": "USD",
-      "frequency": "monthly",
-      "legacy_id": "pro",
-      "is_subscribed": true,
-      "can_subscribe": true
-    },
-    "plan_pending": {
-      "id": "e592fd9519420ba7405e1307bff33214",
-      "name": "Pro Plan",
-      "price": 20,
-      "currency": "USD",
-      "frequency": "monthly",
-      "legacy_id": "pro",
-      "is_subscribed": true,
-      "can_subscribe": true
-    },
-    "status": "active",
-    "paused": false,
-    "type": "full"
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/addZone.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -82,7 +29,8 @@ class ZonesTest extends PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute("id", $result);
         $this->assertEquals("023e105f4ecef8ad9ca31a8372d0c353", $result->id);
 
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createPageRule.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
@@ -103,15 +51,8 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
     public function testActivationTest()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "023e105f4ecef8ad9ca31a8372d0c353"
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/activationTest.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('put')->willReturn($response);
 
@@ -131,69 +72,8 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
     public function testListZones()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": [
-    {
-      "id": "023e105f4ecef8ad9ca31a8372d0c353",
-      "name": "example.com",
-      "development_mode": 7200,
-      "original_name_servers": [
-        "ns1.originaldnshost.com",
-        "ns2.originaldnshost.com"
-      ],
-      "original_registrar": "GoDaddy",
-      "original_dnshost": "NameCheap",
-      "created_on": "2014-01-01T05:20:00.12345Z",
-      "modified_on": "2014-01-01T05:20:00.12345Z",
-      "name_servers": [
-        "tony.ns.cloudflare.com",
-        "woz.ns.cloudflare.com"
-      ],
-      "owner": {
-        "id": "7c5dae5552338874e5053f2534d2767a",
-        "email": "user@example.com",
-        "owner_type": "user"
-      },
-      "permissions": [
-        "#zone:read",
-        "#zone:edit"
-      ],
-      "plan": {
-        "id": "e592fd9519420ba7405e1307bff33214",
-        "name": "Pro Plan",
-        "price": 20,
-        "currency": "USD",
-        "frequency": "monthly",
-        "legacy_id": "pro",
-        "is_subscribed": true,
-        "can_subscribe": true
-      },
-      "plan_pending": {
-        "id": "e592fd9519420ba7405e1307bff33214",
-        "name": "Pro Plan",
-        "price": 20,
-        "currency": "USD",
-        "frequency": "monthly",
-        "legacy_id": "pro",
-        "is_subscribed": true,
-        "can_subscribe": true
-      },
-      "status": "active",
-      "paused": false,
-      "type": "full"
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listZones.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -225,69 +105,8 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
     public function testGetZoneID()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": [
-    {
-      "id": "023e105f4ecef8ad9ca31a8372d0c353",
-      "name": "example.com",
-      "development_mode": 7200,
-      "original_name_servers": [
-        "ns1.originaldnshost.com",
-        "ns2.originaldnshost.com"
-      ],
-      "original_registrar": "GoDaddy",
-      "original_dnshost": "NameCheap",
-      "created_on": "2014-01-01T05:20:00.12345Z",
-      "modified_on": "2014-01-01T05:20:00.12345Z",
-      "name_servers": [
-        "tony.ns.cloudflare.com",
-        "woz.ns.cloudflare.com"
-      ],
-      "owner": {
-        "id": "7c5dae5552338874e5053f2534d2767a",
-        "email": "user@example.com",
-        "owner_type": "user"
-      },
-      "permissions": [
-        "#zone:read",
-        "#zone:edit"
-      ],
-      "plan": {
-        "id": "e592fd9519420ba7405e1307bff33214",
-        "name": "Pro Plan",
-        "price": 20,
-        "currency": "USD",
-        "frequency": "monthly",
-        "legacy_id": "pro",
-        "is_subscribed": true,
-        "can_subscribe": true
-      },
-      "plan_pending": {
-        "id": "e592fd9519420ba7405e1307bff33214",
-        "name": "Pro Plan",
-        "price": 20,
-        "currency": "USD",
-        "frequency": "monthly",
-        "legacy_id": "pro",
-        "is_subscribed": true,
-        "can_subscribe": true
-      },
-      "status": "active",
-      "paused": false,
-      "type": "full"
-    }
-  ],
-  "result_info": {
-    "page": 1,
-    "per_page": 20,
-    "count": 1,
-    "total_count": 2000
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getZoneId.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('get')->willReturn($response);
 
@@ -312,15 +131,8 @@ class ZonesTest extends PHPUnit_Framework_TestCase
 
     public function testCachePurgeEverything()
     {
-        $stream = GuzzleHttp\Psr7\stream_for('{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "023e105f4ecef8ad9ca31a8372d0c353"
-  }
-}');
-        $response = new GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], $stream);
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/cachePurgeEverything.json');
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('delete')->willReturn($response);
 

--- a/tests/Fixtures/Endpoints/activationTest.json
+++ b/tests/Fixtures/Endpoints/activationTest.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353"
+  }
+}

--- a/tests/Fixtures/Endpoints/addLockdown.json
+++ b/tests/Fixtures/Endpoints/addLockdown.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Restrict access to these endpoints to requests from a known IP address",
+    "urls": [
+      "api.mysite.com/some/endpoint*"
+    ],
+    "configurations": [
+      {
+        "target": "ip",
+        "value": "1.2.3.4"
+      }
+    ]
+  }
+}

--- a/tests/Fixtures/Endpoints/addRecord.json
+++ b/tests/Fixtures/Endpoints/addRecord.json
@@ -1,0 +1,20 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "type": "A",
+    "name": "example.com",
+    "content": "1.2.3.4",
+    "proxiable": true,
+    "proxied": false,
+    "ttl": 120,
+    "locked": false,
+    "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+    "zone_name": "example.com",
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "data": {}
+  }
+}

--- a/tests/Fixtures/Endpoints/addZone.json
+++ b/tests/Fixtures/Endpoints/addZone.json
@@ -1,0 +1,54 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353",
+    "name": "example.com",
+    "development_mode": 7200,
+    "original_name_servers": [
+      "ns1.originaldnshost.com",
+      "ns2.originaldnshost.com"
+    ],
+    "original_registrar": "GoDaddy",
+    "original_dnshost": "NameCheap",
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "name_servers": [
+      "tony.ns.cloudflare.com",
+      "woz.ns.cloudflare.com"
+    ],
+    "owner": {
+      "id": "7c5dae5552338874e5053f2534d2767a",
+      "email": "user@example.com",
+      "owner_type": "user"
+    },
+    "permissions": [
+      "#zone:read",
+      "#zone:edit"
+    ],
+    "plan": {
+      "id": "e592fd9519420ba7405e1307bff33214",
+      "name": "Pro Plan",
+      "price": 20,
+      "currency": "USD",
+      "frequency": "monthly",
+      "legacy_id": "pro",
+      "is_subscribed": true,
+      "can_subscribe": true
+    },
+    "plan_pending": {
+      "id": "e592fd9519420ba7405e1307bff33214",
+      "name": "Pro Plan",
+      "price": 20,
+      "currency": "USD",
+      "frequency": "monthly",
+      "legacy_id": "pro",
+      "is_subscribed": true,
+      "can_subscribe": true
+    },
+    "status": "active",
+    "paused": false,
+    "type": "full"
+  }
+}

--- a/tests/Fixtures/Endpoints/cachePurgeEverything.json
+++ b/tests/Fixtures/Endpoints/cachePurgeEverything.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353"
+  }
+}

--- a/tests/Fixtures/Endpoints/createPageRule.json
+++ b/tests/Fixtures/Endpoints/createPageRule.json
@@ -1,0 +1,31 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "9a7806061c88ada191ed06f989cc3dac",
+    "targets": [
+      {
+        "target": "url",
+        "constraint": {
+          "operator": "matches",
+          "value": "*example.com/images/*"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "id": "always_online",
+        "value": "on"
+      }
+    ],
+    "priority": 1,
+    "status": "active",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "created_on": "2014-01-01T05:20:00.12345Z"
+  }
+}

--- a/tests/Fixtures/Endpoints/createRule.json
+++ b/tests/Fixtures/Endpoints/createRule.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
+    "mode": "js_challenge",
+    "configuration": {
+      "target": "ua",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
+    }
+  }
+}

--- a/tests/Fixtures/Endpoints/deleteLockdown.json
+++ b/tests/Fixtures/Endpoints/deleteLockdown.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59"
+  }
+}

--- a/tests/Fixtures/Endpoints/deletePageRule.json
+++ b/tests/Fixtures/Endpoints/deletePageRule.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "9a7806061c88ada191ed06f989cc3dac"
+  }
+}

--- a/tests/Fixtures/Endpoints/deleteRule.json
+++ b/tests/Fixtures/Endpoints/deleteRule.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59"
+  }
+}

--- a/tests/Fixtures/Endpoints/getDNSRecordDetails.json
+++ b/tests/Fixtures/Endpoints/getDNSRecordDetails.json
@@ -1,0 +1,20 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "type": "A",
+    "name": "example.com",
+    "content": "1.2.3.4",
+    "proxiable": true,
+    "proxied": false,
+    "ttl": 120,
+    "locked": false,
+    "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+    "zone_name": "example.com",
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "data": {}
+  }
+}

--- a/tests/Fixtures/Endpoints/getPageRuleDetails.json
+++ b/tests/Fixtures/Endpoints/getPageRuleDetails.json
@@ -1,0 +1,31 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "9a7806061c88ada191ed06f989cc3dac",
+    "targets": [
+      {
+        "target": "url",
+        "constraint": {
+          "operator": "matches",
+          "value": "*example.com/images/*"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "id": "always_online",
+        "value": "on"
+      }
+    ],
+    "priority": 1,
+    "status": "active",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "created_on": "2014-01-01T05:20:00.12345Z"
+  }
+}

--- a/tests/Fixtures/Endpoints/getRecordDetails.json
+++ b/tests/Fixtures/Endpoints/getRecordDetails.json
@@ -1,0 +1,22 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Restrict access to these endpoints to requests from a known IP address",
+    "urls": [
+      "api.mysite.com/some/endpoint*"
+    ],
+    "configurations": [
+      {
+        "target": "ip",
+        "value": "1.2.3.4"
+      }
+    ]
+  }
+}

--- a/tests/Fixtures/Endpoints/getRuleDetails.json
+++ b/tests/Fixtures/Endpoints/getRuleDetails.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
+    "mode": "js_challenge",
+    "configuration": {
+      "target": "ua",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
+    }
+  }
+}

--- a/tests/Fixtures/Endpoints/getUserDetails.json
+++ b/tests/Fixtures/Endpoints/getUserDetails.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "7c5dae5552338874e5053f2534d2767a",
+    "email": "user@example.com",
+    "first_name": "John",
+    "last_name": "Appleseed",
+    "username": "cfuser12345",
+    "telephone": "+1 123-123-1234",
+    "country": "US",
+    "zipcode": "12345",
+    "created_on": "2014-01-01T05:20:00Z",
+    "modified_on": "2014-01-01T05:20:00Z",
+    "two_factor_authentication_enabled": false
+  }
+}

--- a/tests/Fixtures/Endpoints/getUserEmail.json
+++ b/tests/Fixtures/Endpoints/getUserEmail.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "7c5dae5552338874e5053f2534d2767a",
+    "email": "user@example.com",
+    "first_name": "John",
+    "last_name": "Appleseed",
+    "username": "cfuser12345",
+    "telephone": "+1 123-123-1234",
+    "country": "US",
+    "zipcode": "12345",
+    "created_on": "2014-01-01T05:20:00Z",
+    "modified_on": "2014-01-01T05:20:00Z",
+    "two_factor_authentication_enabled": false
+  }
+}

--- a/tests/Fixtures/Endpoints/getUserId.json
+++ b/tests/Fixtures/Endpoints/getUserId.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "7c5dae5552338874e5053f2534d2767a",
+    "email": "user@example.com",
+    "first_name": "John",
+    "last_name": "Appleseed",
+    "username": "cfuser12345",
+    "telephone": "+1 123-123-1234",
+    "country": "US",
+    "zipcode": "12345",
+    "created_on": "2014-01-01T05:20:00Z",
+    "modified_on": "2014-01-01T05:20:00Z",
+    "two_factor_authentication_enabled": false
+  }
+}

--- a/tests/Fixtures/Endpoints/getZoneId.json
+++ b/tests/Fixtures/Endpoints/getZoneId.json
@@ -1,0 +1,62 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "name": "example.com",
+      "development_mode": 7200,
+      "original_name_servers": [
+        "ns1.originaldnshost.com",
+        "ns2.originaldnshost.com"
+      ],
+      "original_registrar": "GoDaddy",
+      "original_dnshost": "NameCheap",
+      "created_on": "2014-01-01T05:20:00.12345Z",
+      "modified_on": "2014-01-01T05:20:00.12345Z",
+      "name_servers": [
+        "tony.ns.cloudflare.com",
+        "woz.ns.cloudflare.com"
+      ],
+      "owner": {
+        "id": "7c5dae5552338874e5053f2534d2767a",
+        "email": "user@example.com",
+        "owner_type": "user"
+      },
+      "permissions": [
+        "#zone:read",
+        "#zone:edit"
+      ],
+      "plan": {
+        "id": "e592fd9519420ba7405e1307bff33214",
+        "name": "Pro Plan",
+        "price": 20,
+        "currency": "USD",
+        "frequency": "monthly",
+        "legacy_id": "pro",
+        "is_subscribed": true,
+        "can_subscribe": true
+      },
+      "plan_pending": {
+        "id": "e592fd9519420ba7405e1307bff33214",
+        "name": "Pro Plan",
+        "price": 20,
+        "currency": "USD",
+        "frequency": "monthly",
+        "legacy_id": "pro",
+        "is_subscribed": true,
+        "can_subscribe": true
+      },
+      "status": "active",
+      "paused": false,
+      "type": "full"
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/listIPs.json
+++ b/tests/Fixtures/Endpoints/listIPs.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "ipv4_cidrs": [
+      "199.27.128.0/21"
+    ],
+    "ipv6_cidrs": [
+      "2400:cb00::/32"
+    ]
+  }
+}

--- a/tests/Fixtures/Endpoints/listLockdowns.json
+++ b/tests/Fixtures/Endpoints/listLockdowns.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "372e67954025e0ba6aaa6d586b9e0b59",
+      "description": "Restrict access to these endpoints to requests from a known IP address",
+      "urls": [
+        "api.mysite.com/some/endpoint*"
+      ],
+      "configurations": [
+        {
+          "target": "ip",
+          "value": "1.2.3.4"
+        }
+      ]
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/listPageRules.json
+++ b/tests/Fixtures/Endpoints/listPageRules.json
@@ -1,0 +1,39 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": [
+    {
+      "id": "9a7806061c88ada191ed06f989cc3dac",
+      "targets": [
+        {
+          "target": "url",
+          "constraint": {
+            "operator": "matches",
+            "value": "*example.com/images/*"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "id": "always_online",
+          "value": "on"
+        }
+      ],
+      "priority": 1,
+      "status": "active",
+      "modified_on": "2014-01-01T05:20:00.12345Z",
+      "created_on": "2014-01-01T05:20:00.12345Z"
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/listRecords.json
+++ b/tests/Fixtures/Endpoints/listRecords.json
@@ -1,0 +1,28 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "372e67954025e0ba6aaa6d586b9e0b59",
+      "type": "A",
+      "name": "example.com",
+      "content": "1.2.3.4",
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 120,
+      "locked": false,
+      "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "zone_name": "example.com",
+      "created_on": "2014-01-01T05:20:00.12345Z",
+      "modified_on": "2014-01-01T05:20:00.12345Z",
+      "data": {}
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/listRules.json
+++ b/tests/Fixtures/Endpoints/listRules.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": [
+    {
+      "id": "372e67954025e0ba6aaa6d586b9e0b59",
+      "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
+      "mode": "js_challenge",
+      "configuration": {
+        "target": "ua",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
+      }
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/listZones.json
+++ b/tests/Fixtures/Endpoints/listZones.json
@@ -1,0 +1,62 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "name": "example.com",
+      "development_mode": 7200,
+      "original_name_servers": [
+        "ns1.originaldnshost.com",
+        "ns2.originaldnshost.com"
+      ],
+      "original_registrar": "GoDaddy",
+      "original_dnshost": "NameCheap",
+      "created_on": "2014-01-01T05:20:00.12345Z",
+      "modified_on": "2014-01-01T05:20:00.12345Z",
+      "name_servers": [
+        "tony.ns.cloudflare.com",
+        "woz.ns.cloudflare.com"
+      ],
+      "owner": {
+        "id": "7c5dae5552338874e5053f2534d2767a",
+        "email": "user@example.com",
+        "owner_type": "user"
+      },
+      "permissions": [
+        "#zone:read",
+        "#zone:edit"
+      ],
+      "plan": {
+        "id": "e592fd9519420ba7405e1307bff33214",
+        "name": "Pro Plan",
+        "price": 20,
+        "currency": "USD",
+        "frequency": "monthly",
+        "legacy_id": "pro",
+        "is_subscribed": true,
+        "can_subscribe": true
+      },
+      "plan_pending": {
+        "id": "e592fd9519420ba7405e1307bff33214",
+        "name": "Pro Plan",
+        "price": 20,
+        "currency": "USD",
+        "frequency": "monthly",
+        "legacy_id": "pro",
+        "is_subscribed": true,
+        "can_subscribe": true
+      },
+      "status": "active",
+      "paused": false,
+      "type": "full"
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/updateLockdown.json
+++ b/tests/Fixtures/Endpoints/updateLockdown.json
@@ -1,0 +1,22 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Restrict access to these endpoints to requests from a known IP address",
+    "urls": [
+      "api.mysite.com/some/endpoint*"
+    ],
+    "configurations": [
+      {
+        "target": "ip",
+        "value": "1.2.3.4"
+      }
+    ]
+  }
+}

--- a/tests/Fixtures/Endpoints/updatePageRule.json
+++ b/tests/Fixtures/Endpoints/updatePageRule.json
@@ -1,0 +1,31 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "9a7806061c88ada191ed06f989cc3dac",
+    "targets": [
+      {
+        "target": "url",
+        "constraint": {
+          "operator": "matches",
+          "value": "*example.com/images/*"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "id": "always_online",
+        "value": "on"
+      }
+    ],
+    "priority": 1,
+    "status": "active",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "created_on": "2014-01-01T05:20:00.12345Z"
+  }
+}

--- a/tests/Fixtures/Endpoints/updateRule.json
+++ b/tests/Fixtures/Endpoints/updateRule.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "372e67954025e0ba6aaa6d586b9e0b59",
+    "description": "Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack",
+    "mode": "js_challenge",
+    "configuration": {
+      "target": "ua",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4"
+    }
+  }
+}

--- a/tests/Fixtures/Endpoints/updateUserDetails.json
+++ b/tests/Fixtures/Endpoints/updateUserDetails.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "7c5dae5552338874e5053f2534d2767a",
+    "email": "user@example.com",
+    "first_name": "John",
+    "last_name": "Appleseed",
+    "username": "cfuser12345",
+    "telephone": "+1 123-123-1234",
+    "country": "US",
+    "zipcode": "12345",
+    "created_on": "2014-01-01T05:20:00Z",
+    "modified_on": "2014-01-01T05:20:00Z",
+    "two_factor_authentication_enabled": false
+  }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,41 @@
+<?php
+use GuzzleHttp\Psr7;
+
+abstract class TestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Returns a PSR7 Stream for a given fixture.
+     *
+     * @param  string     $fixture The fixture to create the stream for.
+     * @return Psr7Stream
+     */
+    protected function getPsr7StreamForFixture($fixture): Psr7\Stream
+    {
+        $path = sprintf('%s/Fixtures/%s', __DIR__, $fixture);
+
+        $this->assertFileExists($path);
+
+        $stream = Psr7\stream_for(file_get_contents($path));
+
+        $this->assertInstanceOf(Psr7\Stream::class, $stream);
+
+        return $stream;
+    }
+
+    /**
+     * Returns a PSR7 Response (JSON) for a given fixture.
+     *
+     * @param  string        $fixture    The fixture to create the response for.
+     * @param  integer       $statusCode A HTTP Status Code for the response.
+     * @return Psr7Response
+     */
+    protected function getPsr7JsonResponseForFixture($fixture, $statusCode = 200): Psr7\Response
+    {
+        $stream = $this->getPsr7StreamForFixture($fixture);
+
+        $this->assertNotNull(json_decode($stream));
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+
+        return new Psr7\Response($statusCode, ['Content-Type' => 'application/json'], $stream);
+    }
+}


### PR DESCRIPTION
This PR moves the JSON API responses used in the tests to fixture files
within the tests folder. This allows reuse and the ability to lint/validate
these fixtures if required - although not covered in this PR.

I've added `TestCase::getPsr7StreamForFixture` and `TestCase::getPsr7JsonResponseForFixture`
to reduce code duplication and enable some assertions around the expected fixures/responses.

Thanks,