### PR TITLE
Inconsistent Array Declaration

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,7 @@ return PhpCsFixer\Config::create()
     ->setUsingCache(false)
     ->setRules([
         '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder($finder)
 ;

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -37,7 +37,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function get(String $uri, array $query = array(), array $headers = array()): ResponseInterface
+    public function get(String $uri, array $query = [], array $headers = []): ResponseInterface
     {
         $response = $this->client->get($uri, ['query' => $query, 'headers' => $headers]);
 
@@ -48,7 +48,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function post(String $uri, array $headers = array(), array $body = array()): ResponseInterface
+    public function post(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->post(
             $uri,
@@ -65,7 +65,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function put(String $uri, array $headers = array(), array $body = array()): ResponseInterface
+    public function put(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $jsonBody = json_encode($body);
 
@@ -84,7 +84,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function patch(String $uri, array $headers = array(), array $body = array()): ResponseInterface
+    public function patch(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $jsonBody = json_encode($body);
 
@@ -103,7 +103,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function delete(String $uri, array $headers = array(), array $body = array()): ResponseInterface
+    public function delete(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->delete(
             $uri,

--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -10,7 +10,7 @@ namespace Cloudflare\API\Configurations;
 
 class PageRulesActions implements Configurations
 {
-    private $configs = array();
+    private $configs = [];
 
     public function setAlwaysOnline(bool $active)
     {

--- a/src/Configurations/UARules.php
+++ b/src/Configurations/UARules.php
@@ -10,7 +10,7 @@ namespace Cloudflare\API\Configurations;
 
 class UARules implements Configurations
 {
-    private $configs = array();
+    private $configs = [];
 
     public function addUA(string $value)
     {

--- a/src/Configurations/ZoneLockdown.php
+++ b/src/Configurations/ZoneLockdown.php
@@ -10,7 +10,7 @@ namespace Cloudflare\API\Configurations;
 
 class ZoneLockdown implements Configurations
 {
-    private $configs = array();
+    private $configs = [];
 
     public function addIP(string $value)
     {


### PR DESCRIPTION
This PR normalises the declaration of arrays throughout the project, and adds
this to the php-cs-fixer rules.

I've chosen "short" by default, but happy to change the PR to use "long" if
preferred.

Thanks,