### PR TITLE
Don't double JSON-encode the request

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -67,13 +67,11 @@ class Guzzle implements Adapter
      */
     public function put(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
-        $jsonBody = json_encode($body);
-
         $response = $this->client->put(
             $uri,
             [
                 'headers' => $headers,
-                'json' => $jsonBody
+                'json' => $body
             ]
         );
 
@@ -86,13 +84,11 @@ class Guzzle implements Adapter
      */
     public function patch(String $uri, array $headers = [], array $body = []): ResponseInterface
     {
-        $jsonBody = json_encode($body);
-
         $response = $this->client->patch(
             $uri,
             [
                 'headers' => $headers,
-                'json' => $jsonBody
+                'json' => $body
             ]
         );
 

--- a/tests/Adapter/GuzzleTest.php
+++ b/tests/Adapter/GuzzleTest.php
@@ -58,7 +58,7 @@ class GuzzleTest extends TestCase
         $this->assertEquals("application/json", $headers["Content-Type"][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a PUT request.", json_decode($body->json)->{"X-Put-Test"});
+        $this->assertEquals("Testing a PUT request.", $body->json->{"X-Put-Test"});
     }
 
     public function testPatch()
@@ -73,7 +73,7 @@ class GuzzleTest extends TestCase
         $this->assertEquals("application/json", $headers["Content-Type"][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a PATCH request.", json_decode($body->json)->{"X-Patch-Test"});
+        $this->assertEquals("Testing a PATCH request.", $body->json->{"X-Patch-Test"});
     }
 
     public function testDelete()


### PR DESCRIPTION
This PR should fix #19 

Guzzle provides a JSON middleware which is activated by using the [`json` parameter in the request options](http://docs.guzzlephp.org/en/stable/request-options.html#json). That parameter takes an array and then automatically converts it to json (by calling `json_encode()`).

By removing the extraneous calls to `json_encode()`, the `put()` and `patch()` pass an array to Guzzle which then converts it to valid JSON which is sent to Cloudflare's API endpoints. By having these extra `json_encode()`s, the string get's "double-JSON'ed" and thus becomes invalid [as discovered](https://github.com/cloudflare/cloudflare-php/issues/19#issuecomment-333905838) by some excellent debugging by @CodeBradley.

Let me know if you'd like me to make any changes!