### PR TITLE
About cache - 1107 Error code

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -119,9 +119,9 @@ class Zones implements API
         return false;
     }
 
-    public function cachePurge(string $zoneID, array $files = [], array $tags = []): bool
+    public function cachePurge(string $zoneID, array $files = null, array $tags = null): bool
     {
-        if (empty($files) && empty($tags)) {
+        if (is_null($files) && is_null($tags)) {
             throw new EndpointException("No files or tags to purge.");
         }
 


### PR DESCRIPTION
{"success":false,"errors":[{"code":1107,"message":"Only enterprise zones can purge by tag."}],"messages":[],"result":nul (truncated...) in 


Problem solved.