### PR TITLE
Add firewall access rules endpoint

### DIFF
--- a/src/Configurations/AccessRules.php
+++ b/src/Configurations/AccessRules.php
@@ -2,26 +2,26 @@
 
 namespace Cloudflare\API\Configurations;
 
-class AccessRules
+class AccessRules implements Configurations
 {
     private $config;
 
     public function setIP(string $value)
     {
-        $this->config = (object)['target' => 'ip', 'value' => $value];
+        $this->config = ['target' => 'ip', 'value' => $value];
     }
 
     public function setIPRange(string $value)
     {
-        $this->config = (object)['target' => 'ip_range', 'value' => $value];
+        $this->config = ['target' => 'ip_range', 'value' => $value];
     }
 
     public function setCountry(string $value)
     {
-        $this->config = (object)['target' => 'country', 'value' => $value];
+        $this->config = ['target' => 'country', 'value' => $value];
     }
 
-    public function getObject(): \stdClass
+    public function getArray(): array
     {
         return $this->config;
     }

--- a/src/Configurations/AccessRules.php
+++ b/src/Configurations/AccessRules.php
@@ -2,27 +2,27 @@
 
 namespace Cloudflare\API\Configurations;
 
-class AccessRules implements Configurations
+class AccessRules
 {
-    private $configs = [];
+    private $config;
 
     public function setIP(string $value)
     {
-        $this->configs[] = (object)['target' => 'ip', 'value' => $value];
+        $this->config = (object)['target' => 'ip', 'value' => $value];
     }
 
     public function setIPRange(string $value)
     {
-        $this->configs[] = (object)['target' => 'ip_range', 'value' => $value];
+        $this->config = (object)['target' => 'ip_range', 'value' => $value];
     }
 
     public function setCountry(string $value)
     {
-        $this->configs[] = (object)['target' => 'country', 'value' => $value];
+        $this->config = (object)['target' => 'country', 'value' => $value];
     }
 
-    public function getArray(): array
+    public function getObject(): \stdClass
     {
-        return $this->configs;
+        return $this->config;
     }
 }

--- a/src/Configurations/AccessRules.php
+++ b/src/Configurations/AccessRules.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cloudflare\API\Configurations;
+
+class AccessRules implements Configurations
+{
+    private $configs = [];
+
+    public function setIP(string $value)
+    {
+        $this->configs[] = (object)['target' => 'ip', 'value' => $value];
+    }
+
+    public function setIPRange(string $value)
+    {
+        $this->configs[] = (object)['target' => 'ip_range', 'value' => $value];
+    }
+
+    public function setCountry(string $value)
+    {
+        $this->configs[] = (object)['target' => 'country', 'value' => $value];
+    }
+
+    public function getArray(): array
+    {
+        return $this->configs;
+    }
+}

--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -14,6 +14,22 @@ class AccessRules implements API
         $this->adapter = $adapter;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     *
+     * @param string $zoneID
+     * @param string $scopeType
+     * @param string $mode
+     * @param string $configurationTarget
+     * @param string $configurationValue
+     * @param int $page
+     * @param int $perPage
+     * @param string $order
+     * @param string $direction
+     * @param string $match
+     * @param string $notes
+     * @return \stdClass
+     */
     public function listRules(
         string $zoneID,
         string $scopeType = '',
@@ -70,12 +86,12 @@ class AccessRules implements API
     public function createRule(
         string $zoneID,
         string $mode,
-        \Cloudflare\API\Configurations\AccessRules $configuration,
+        Configurations $configuration,
         string $notes = null
     ): bool {
         $options = [
             'mode' => $mode,
-            'configuration' => $configuration->getObject()
+            'configuration' => (object) $configuration->getArray()
         ];
 
         if ($notes !== null) {

--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -70,12 +70,12 @@ class AccessRules implements API
     public function createRule(
         string $zoneID,
         string $mode,
-        Configurations $configuration,
+        \Cloudflare\API\Configurations\AccessRules $configuration,
         string $notes = null
     ): bool {
         $options = [
             'mode' => $mode,
-            'configuration' => $configuration->getArray()
+            'configuration' => $configuration->getObject()
         ];
 
         if ($notes !== null) {

--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Cloudflare\API\Endpoints;
+
+use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Configurations\Configurations;
+
+class AccessRules implements API
+{
+    private $adapter;
+
+    public function __construct(Adapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    public function listRules(
+        string $zoneID,
+        string $scopeType = '',
+        string $mode = '',
+        string $configurationTarget = '',
+        string $configurationValue = '',
+        int $page = 1,
+        int $perPage = 50,
+        string $order = '',
+        string $direction = '',
+        string $match = 'all',
+        string $notes = ''
+    ): \stdClass {
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+            'match' => $match
+        ];
+
+        if (!empty($scopeType)) {
+            $query['scope_type'] = $scopeType;
+        }
+
+        if (!empty($mode)) {
+            $query['mode'] = $mode;
+        }
+
+        if (!empty($configurationTarget)) {
+            $query['configuration_target'] = $configurationTarget;
+        }
+
+        if (!empty($configurationValue)) {
+            $query['configuration_value'] = $configurationValue;
+        }
+
+        if (!empty($order)) {
+            $query['order'] = $order;
+        }
+
+        if (!empty($direction)) {
+            $query['direction'] = $direction;
+        }
+
+        if (!empty($notes)) {
+            $query['notes'] = $notes;
+        }
+
+        $data = $this->adapter->get('zones/' . $zoneID . '/firewall/access_rules/rules', $query, []);
+        $body = json_decode($data->getBody());
+
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+    }
+
+    public function createRule(
+        string $zoneID,
+        string $mode,
+        Configurations $configuration,
+        string $notes = null
+    ): bool {
+        $options = [
+            'mode' => $mode,
+            'configuration' => $configuration->getArray()
+        ];
+
+        if ($notes !== null) {
+            $options['notes'] = $notes;
+        }
+
+        $query = $this->adapter->post('zones/' . $zoneID . '/firewall/access_rules/rules', [], $options);
+
+        $body = json_decode($query->getBody());
+
+        if (isset($body->result->id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function updateRule(
+        string $zoneID,
+        string $ruleID,
+        string $mode,
+        string $notes = null
+    ): bool {
+        $options = [
+            'mode' => $mode
+        ];
+
+        if ($notes !== null) {
+            $options['notes'] = $notes;
+        }
+
+        $query = $this->adapter->patch('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, [], $options);
+
+        $body = json_decode($query->getBody());
+
+        if (isset($body->result->id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function deleteRule(string $zoneID, string $ruleID, string $cascade = 'none'): bool
+    {
+        $options = [
+            'cascade' => $cascade
+        ];
+
+        $data = $this->adapter->delete('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, [], $options);
+
+        $body = json_decode($data->getBody());
+
+        if (isset($body->result->id)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Endpoints/AccessRulesTest.php
+++ b/tests/Endpoints/AccessRulesTest.php
@@ -48,7 +48,7 @@ class AccessRulesTest extends TestCase
                 $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'challenge',
-                    'configuration' => $config->getObject(),
+                    'configuration' => (object) $config->getArray(),
                     'notes' => 'This rule is on because of an event that occured on date X',
                 ])
             );

--- a/tests/Endpoints/AccessRulesTest.php
+++ b/tests/Endpoints/AccessRulesTest.php
@@ -1,0 +1,112 @@
+<?php
+
+class AccessRulesTest extends TestCase
+{
+    public function testListRules()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listAccessRules.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('get')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules'),
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 50,
+                    'match' => 'all'
+                ]),
+                $this->equalTo([])
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\AccessRules($mock);
+        $result = $zones->listRules('023e105f4ecef8ad9ca31a8372d0c353');
+
+        $this->assertObjectHasAttribute('result', $result);
+        $this->assertObjectHasAttribute('result_info', $result);
+
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $result->result[0]->id);
+        $this->assertEquals(1, $result->result_info->page);
+    }
+
+    public function testCreateRule()
+    {
+        $config = new \Cloudflare\API\Configurations\AccessRules();
+        $config->setIP('1.2.3.4');
+
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createAccessRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules'),
+                $this->equalTo([]),
+                $this->equalTo([
+                    'mode' => 'challenge',
+                    'configuration' => $config->getArray(),
+                    'notes' => 'This rule is on because of an event that occured on date X',
+                ])
+            );
+
+        $rules = new \Cloudflare\API\Endpoints\AccessRules($mock);
+        $rules->createRule(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            'challenge',
+            $config,
+            'This rule is on because of an event that occured on date X'
+        );
+    }
+
+    public function testUpdateRule()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateAccessRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('patch')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('patch')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules/92f17202ed8bd63d69a66b86a49a8f6b'),
+                $this->equalTo([]),
+                $this->equalTo([
+                    'mode' => 'challenge',
+                    'notes' => 'This rule is on because of an event that occured on date X',
+                ])
+            );
+
+        $rules = new \Cloudflare\API\Endpoints\AccessRules($mock);
+        $rules->updateRule(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            '92f17202ed8bd63d69a66b86a49a8f6b',
+            'challenge',
+            'This rule is on because of an event that occured on date X'
+        );
+    }
+
+    public function testDeleteRule()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/deleteAccessRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('delete')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules/92f17202ed8bd63d69a66b86a49a8f6b'),
+                $this->equalTo([]),
+                $this->equalTo([
+                    'cascade' => 'none'
+                ])
+            );
+
+        $rules = new \Cloudflare\API\Endpoints\AccessRules($mock);
+        $rules->deleteRule('023e105f4ecef8ad9ca31a8372d0c353', '92f17202ed8bd63d69a66b86a49a8f6b');
+    }
+}

--- a/tests/Endpoints/AccessRulesTest.php
+++ b/tests/Endpoints/AccessRulesTest.php
@@ -48,7 +48,7 @@ class AccessRulesTest extends TestCase
                 $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'challenge',
-                    'configuration' => $config->getArray(),
+                    'configuration' => $config->getObject(),
                     'notes' => 'This rule is on because of an event that occured on date X',
                 ])
             );

--- a/tests/Fixtures/Endpoints/createAccessRule.json
+++ b/tests/Fixtures/Endpoints/createAccessRule.json
@@ -1,0 +1,30 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "92f17202ed8bd63d69a66b86a49a8f6b",
+    "notes": "This rule is on because of an event that occured on date X",
+    "allowed_modes": [
+      "whitelist",
+      "block",
+      "challenge"
+    ],
+    "mode": "challenge",
+    "configuration": {
+      "target": "ip",
+      "value": "1.2.3.4"
+    },
+    "scope": {
+      "id": "7c5dae5552338874e5053f2534d2767a",
+      "email": "user@example.com",
+      "type": "user"
+    },
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z"
+  }
+}

--- a/tests/Fixtures/Endpoints/deleteAccessRule.json
+++ b/tests/Fixtures/Endpoints/deleteAccessRule.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "92f17202ed8bd63d69a66b86a49a8f6b"
+  }
+}

--- a/tests/Fixtures/Endpoints/listAccessRules.json
+++ b/tests/Fixtures/Endpoints/listAccessRules.json
@@ -1,0 +1,38 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": [
+    {
+      "id": "92f17202ed8bd63d69a66b86a49a8f6b",
+      "notes": "This rule is on because of an event that occured on date X",
+      "allowed_modes": [
+        "whitelist",
+        "block",
+        "challenge"
+      ],
+      "mode": "challenge",
+      "configuration": {
+        "target": "ip",
+        "value": "1.2.3.4"
+      },
+      "scope": {
+        "id": "7c5dae5552338874e5053f2534d2767a",
+        "email": "user@example.com",
+        "type": "user"
+      },
+      "created_on": "2014-01-01T05:20:00.12345Z",
+      "modified_on": "2014-01-01T05:20:00.12345Z"
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}

--- a/tests/Fixtures/Endpoints/updateAccessRule.json
+++ b/tests/Fixtures/Endpoints/updateAccessRule.json
@@ -1,0 +1,30 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "id": "92f17202ed8bd63d69a66b86a49a8f6b",
+    "notes": "This rule is on because of an event that occured on date X",
+    "allowed_modes": [
+      "whitelist",
+      "block",
+      "challenge"
+    ],
+    "mode": "challenge",
+    "configuration": {
+      "target": "ip",
+      "value": "1.2.3.4"
+    },
+    "scope": {
+      "id": "7c5dae5552338874e5053f2534d2767a",
+      "email": "user@example.com",
+      "type": "user"
+    },
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z"
+  }
+}


### PR DESCRIPTION
This PR implements the endpoint for firewall access rules (for a zone). Travis will fail because of:
```
/cloudflare-php/src/Endpoints/AccessRules.php:17  The method listRules has 11 parameters. Consider reducing the number of parameters to less than 10.
```

(Maybe the [`ExcessiveParameterList`](https://phpmd.org/rules/codesize.html#excessiveparameterlist) rule needs to set to >= 11).