### PR TITLE
Cleanup / fixes

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -21,56 +21,56 @@ interface Adapter
      * Adapter constructor.
      *
      * @param Auth $auth
-     * @param String $baseURI
+     * @param string $baseURI
      */
-    public function __construct(Auth $auth, String $baseURI);
+    public function __construct(Auth $auth, string $baseURI);
 
     /**
      * Sends a GET request.
      * Per Robustness Principle - not including the ability to send a body with a GET request (though possible in the
      * RFCs, it is never useful).
      *
-     * @param String $uri
+     * @param string $uri
      * @param array $query
      * @param array $headers
      *
      * @return mixed
      */
-    public function get(String $uri, array $query, array $headers): ResponseInterface;
+    public function get(string $uri, array $query, array $headers): ResponseInterface;
 
     /**
-     * @param String $uri
+     * @param string $uri
      * @param array $headers
      * @param array $body
      *
      * @return mixed
      */
-    public function post(String $uri, array $headers, array $body): ResponseInterface;
+    public function post(string $uri, array $headers, array $body): ResponseInterface;
 
     /**
-     * @param String $uri
+     * @param string $uri
      * @param array $headers
      * @param array $body
      *
      * @return mixed
      */
-    public function put(String $uri, array $headers, array $body): ResponseInterface;
+    public function put(string $uri, array $headers, array $body): ResponseInterface;
 
     /**
-     * @param String $uri
+     * @param string $uri
      * @param array $headers
      * @param array $body
      *
      * @return mixed
      */
-    public function patch(String $uri, array $headers, array $body): ResponseInterface;
+    public function patch(string $uri, array $headers, array $body): ResponseInterface;
 
     /**
-     * @param String $uri
+     * @param string $uri
      * @param array $headers
      * @param array $body
      *
      * @return mixed
      */
-    public function delete(String $uri, array $headers, array $body): ResponseInterface;
+    public function delete(string $uri, array $headers, array $body): ResponseInterface;
 }

--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -31,6 +31,7 @@ interface Adapter
      * RFCs, it is never useful).
      *
      * @param String $uri
+     * @param array $query
      * @param array $headers
      *
      * @return mixed

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -21,7 +21,7 @@ class Guzzle implements Adapter
     public function __construct(Auth $auth, String $baseURI = null)
     {
         if ($baseURI === null) {
-            $baseURI = "https://api.cloudflare.com/client/v4/";
+            $baseURI = 'https://api.cloudflare.com/client/v4/';
         }
 
         $headers = $auth->getHeaders();
@@ -128,7 +128,7 @@ class Guzzle implements Adapter
         }
 
         if (isset($json->success) && ($json->success === false)) {
-            throw new ResponseException("Request was unsuccessful.");
+            throw new ResponseException('Request was unsuccessful.');
         }
     }
 }

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -18,7 +18,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function __construct(Auth $auth, String $baseURI = null)
+    public function __construct(Auth $auth, string $baseURI = null)
     {
         if ($baseURI === null) {
             $baseURI = 'https://api.cloudflare.com/client/v4/';
@@ -37,7 +37,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function get(String $uri, array $query = [], array $headers = []): ResponseInterface
+    public function get(string $uri, array $query = [], array $headers = []): ResponseInterface
     {
         $response = $this->client->get($uri, ['query' => $query, 'headers' => $headers]);
 
@@ -48,7 +48,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function post(String $uri, array $headers = [], array $body = []): ResponseInterface
+    public function post(string $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->post(
             $uri,
@@ -65,7 +65,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function put(String $uri, array $headers = [], array $body = []): ResponseInterface
+    public function put(string $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->put(
             $uri,
@@ -82,7 +82,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function patch(String $uri, array $headers = [], array $body = []): ResponseInterface
+    public function patch(string $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->patch(
             $uri,
@@ -99,7 +99,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function delete(String $uri, array $headers = [], array $body = []): ResponseInterface
+    public function delete(string $uri, array $headers = [], array $body = []): ResponseInterface
     {
         $response = $this->client->delete(
             $uri,

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -122,9 +122,7 @@ class Guzzle implements Adapter
         }
 
         if (isset($json->errors)) {
-            foreach ($json->errors as $error) {
-                throw new ResponseException($error->message, $error->code);
-            }
+            throw new ResponseException($json->errors[0]->message, $json->errors[0]->code);
         }
 
         if (isset($json->success) && ($json->success === false)) {

--- a/src/Auth/APIKey.php
+++ b/src/Auth/APIKey.php
@@ -12,7 +12,7 @@ class APIKey implements Auth
     private $email;
     private $apiKey;
 
-    public function __construct(String $email, String $apiKey)
+    public function __construct(string $email, string $apiKey)
     {
         $this->email  = $email;
         $this->apiKey = $apiKey;

--- a/src/Auth/UserServiceKey.php
+++ b/src/Auth/UserServiceKey.php
@@ -11,7 +11,7 @@ class UserServiceKey implements Auth
 {
     private $userServiceKey;
 
-    public function __construct(String $userServiceKey)
+    public function __construct(string $userServiceKey)
     {
         $this->userServiceKey = $userServiceKey;
     }

--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -14,28 +14,28 @@ class PageRulesActions implements Configurations
 
     public function setAlwaysOnline(bool $active)
     {
-        $this->addConfigurationOption("always_online", [
+        $this->addConfigurationOption('always_online', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setAlwaysUseHTTPS(bool $active)
     {
-        $this->addConfigurationOption("always_use_https", [
+        $this->addConfigurationOption('always_use_https', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setBrowserCacheTTL(int $ttl)
     {
-        $this->addConfigurationOption("browser_cache_ttl", [
+        $this->addConfigurationOption('browser_cache_ttl', [
             'value' => $ttl
         ]);
     }
 
     public function setBrowserIntegrityCheck(bool $active)
     {
-        $this->addConfigurationOption("browser_check", [
+        $this->addConfigurationOption('browser_check', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
@@ -43,35 +43,35 @@ class PageRulesActions implements Configurations
     public function setBypassCacheOnCookie(string $value)
     {
         if (preg_match('/^([a-zA-Z0-9\.=|_*-]+)$/i', $value) < 1) {
-            throw new ConfigurationsException("Invalid cookie string.");
+            throw new ConfigurationsException('Invalid cookie string.');
         }
 
-        $this->addConfigurationOption("bypass_cache_on_cookie", [
+        $this->addConfigurationOption('bypass_cache_on_cookie', [
             'value' => $value
         ]);
     }
 
     public function setCacheByDeviceType(bool $active)
     {
-        $this->addConfigurationOption("cache_by_device_type", [
+        $this->addConfigurationOption('cache_by_device_type', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setCacheKey(string $value)
     {
-        $this->addConfigurationOption("cache_key", [
+        $this->addConfigurationOption('cache_key', [
             'value' => $value
         ]);
     }
 
     public function setCacheLevel(string $value)
     {
-        if (!in_array($value, ["bypass", "basic", "simplified", "aggressive", "cache_everything"])) {
-            throw new ConfigurationsException("Invalid cache level");
+        if (!in_array($value, ['bypass', 'basic', 'simplified', 'aggressive', 'cache_everything'])) {
+            throw new ConfigurationsException('Invalid cache level');
         }
 
-        $this->addConfigurationOption("cache_level", [
+        $this->addConfigurationOption('cache_level', [
             'value' => $value
         ]);
     }
@@ -79,31 +79,31 @@ class PageRulesActions implements Configurations
     public function setCacheOnCookie(string $value)
     {
         if (preg_match('/^([a-zA-Z0-9\.=|_*-]+)$/i', $value) < 1) {
-            throw new ConfigurationsException("Invalid cookie string.");
+            throw new ConfigurationsException('Invalid cookie string.');
         }
 
-        $this->addConfigurationOption("cache_on_cookie", [
+        $this->addConfigurationOption('cache_on_cookie', [
             'value' => $value
         ]);
     }
 
     public function setDisableApps(bool $active)
     {
-        $this->addConfigurationOption("disable_apps", [
+        $this->addConfigurationOption('disable_apps', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setDisablePerformance(bool $active)
     {
-        $this->addConfigurationOption("disable_performance", [
+        $this->addConfigurationOption('disable_performance', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setDisableSecurity(bool $active)
     {
-        $this->addConfigurationOption("disable_security", [
+        $this->addConfigurationOption('disable_security', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
@@ -111,17 +111,17 @@ class PageRulesActions implements Configurations
     public function setEdgeCacheTTL(int $value)
     {
         if ($value > 2419200) {
-            throw new ConfigurationsException("Edge Cache TTL too high.");
+            throw new ConfigurationsException('Edge Cache TTL too high.');
         }
 
-        $this->addConfigurationOption("edge_cache_ttl", [
+        $this->addConfigurationOption('edge_cache_ttl', [
             'value' => $value
         ]);
     }
 
     public function setEmailObfuscation(bool $active)
     {
-        $this->addConfigurationOption("disable_security", [
+        $this->addConfigurationOption('disable_security', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
@@ -132,7 +132,7 @@ class PageRulesActions implements Configurations
             throw new ConfigurationsException('Status Codes can only be 301 or 302.');
         }
 
-        $this->addConfigurationOption("forwarding_url", [
+        $this->addConfigurationOption('forwarding_url', [
             'status_code' => $statusCode,
             'url' => $forwardingUrl,
         ]);
@@ -140,28 +140,28 @@ class PageRulesActions implements Configurations
 
     public function setHostHeaderOverride(bool $active)
     {
-        $this->addConfigurationOption("host_header_override", [
+        $this->addConfigurationOption('host_header_override', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setHotlinkProtection(bool $active)
     {
-        $this->addConfigurationOption("hotlink_protection", [
+        $this->addConfigurationOption('hotlink_protection', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setIPGeoLocationHeader(bool $active)
     {
-        $this->addConfigurationOption("ip_geolocation", [
+        $this->addConfigurationOption('ip_geolocation', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setMinification(bool $html, bool $css, bool $javascript)
     {
-        $this->addConfigurationOption("minification", [
+        $this->addConfigurationOption('minification', [
             'html' => $this->getBoolAsOnOrOff($html),
             'css' => $this->getBoolAsOnOrOff($css),
             'js' => $this->getBoolAsOnOrOff($javascript),
@@ -170,124 +170,124 @@ class PageRulesActions implements Configurations
 
     public function setMirage(bool $active)
     {
-        $this->addConfigurationOption("mirage", [
+        $this->addConfigurationOption('mirage', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setOriginErrorPagePassthru(bool $active)
     {
-        $this->addConfigurationOption("origin_error_page_pass_thru", [
+        $this->addConfigurationOption('origin_error_page_pass_thru', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setQueryStringSort(bool $active)
     {
-        $this->addConfigurationOption("sort_query_string_for_cache", [
+        $this->addConfigurationOption('sort_query_string_for_cache', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setDisableRailgun(bool $active)
     {
-        $this->addConfigurationOption("disable_railgun", [
+        $this->addConfigurationOption('disable_railgun', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setResolveOverride(bool $value)
     {
-        $this->addConfigurationOption("resolve_override", [
+        $this->addConfigurationOption('resolve_override', [
             'value' => $value
         ]);
     }
 
     public function setRespectStrongEtag(bool $active)
     {
-        $this->addConfigurationOption("respect_strong_etag", [
+        $this->addConfigurationOption('respect_strong_etag', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setResponseBuffering(bool $active)
     {
-        $this->addConfigurationOption("response_buffering", [
+        $this->addConfigurationOption('response_buffering', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setRocketLoader(string $value)
     {
-        if (!in_array($value, ["off", "manual", "automatic"])) {
+        if (!in_array($value, ['off', 'manual', 'automatic'])) {
             throw new ConfigurationsException('Rocket Loader can only be off, automatic, or manual.');
         }
 
-        $this->addConfigurationOption("rocket_loader", [
+        $this->addConfigurationOption('rocket_loader', [
             'value' => $value
         ]);
     }
 
     public function setSecurityLevel(string $value)
     {
-        if (!in_array($value, ["off", "essentially_off", "low", "medium", "high", "under_attack"])) {
+        if (!in_array($value, ['off', 'essentially_off', 'low', 'medium', 'high', 'under_attack'])) {
             throw new ConfigurationsException('Can only be set to off, essentially_off, low, medium, high or under_attack.');
         }
 
-        $this->addConfigurationOption("security_level", [
+        $this->addConfigurationOption('security_level', [
             'value' => $value
         ]);
     }
 
     public function setServerSideExcludes(bool $active)
     {
-        $this->addConfigurationOption("server_side_exclude", [
+        $this->addConfigurationOption('server_side_exclude', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setSmartErrors(bool $active)
     {
-        $this->addConfigurationOption("smart_errors", [
+        $this->addConfigurationOption('smart_errors', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setSSL(string $value)
     {
-        if (!in_array($value, ["off", "flexible", "full", "strict", "origin_pull"])) {
+        if (!in_array($value, ['off', 'flexible', 'full', 'strict', 'origin_pull'])) {
             throw new ConfigurationsException('Can only be set to off, flexible, full, strict, origin_pull.');
         }
 
-        $this->addConfigurationOption("smart_errors", [
+        $this->addConfigurationOption('smart_errors', [
             'value' => $value
         ]);
     }
 
     public function setTrueClientIpHeader(bool $active)
     {
-        $this->addConfigurationOption("true_client_ip_header", [
+        $this->addConfigurationOption('true_client_ip_header', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setWAF(bool $active)
     {
-        $this->addConfigurationOption("waf", [
+        $this->addConfigurationOption('waf', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setAutomatedHTTPSRewrites(bool $active)
     {
-        $this->addConfigurationOption("automatic_https_rewrites", [
+        $this->addConfigurationOption('automatic_https_rewrites', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }
 
     public function setOpportunisticEncryption(bool $active)
     {
-        $this->addConfigurationOption("opportunistic_encryption", [
+        $this->addConfigurationOption('opportunistic_encryption', [
             'value' => $this->getBoolAsOnOrOff($active)
         ]);
     }

--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -301,7 +301,7 @@ class PageRulesActions implements Configurations
     {
         $configuration['id'] = $setting;
 
-        array_push($this->configs, (object) $configuration);
+        $this->configs[] = (object) $configuration;
     }
 
     private function getBoolAsOnOrOff(bool $value): string

--- a/src/Configurations/PageRulesTargets.php
+++ b/src/Configurations/PageRulesTargets.php
@@ -17,7 +17,7 @@ class PageRulesTargets implements Configurations
         $target = new \stdClass();
         $target->target = 'url';
         $target->constraint = new \stdClass();
-        $target->constraint->operator = "matches";
+        $target->constraint->operator = 'matches';
         $target->constraint->value = $queryUrl;
 
         $this->targets = [$target];

--- a/src/Configurations/PageRulesTargets.php
+++ b/src/Configurations/PageRulesTargets.php
@@ -14,13 +14,15 @@ class PageRulesTargets implements Configurations
 
     public function __construct(string $queryUrl)
     {
-        $target = new \stdClass();
-        $target->target = 'url';
-        $target->constraint = new \stdClass();
-        $target->constraint->operator = 'matches';
-        $target->constraint->value = $queryUrl;
-
-        $this->targets = [$target];
+        $this->targets = [
+            (object)[
+                'target' => 'url',
+                'constraint' => (object)[
+                    'operator' => 'matches',
+                    'value' => $queryUrl
+                ]
+            ]
+        ];
     }
 
     public function getArray(): array

--- a/src/Configurations/UARules.php
+++ b/src/Configurations/UARules.php
@@ -14,9 +14,7 @@ class UARules implements Configurations
 
     public function addUA(string $value)
     {
-        $object = (object)['target' => 'ua', 'value' => $value];
-
-        array_push($this->configs, $object);
+        $this->configs[] = (object)['target' => 'ua', 'value' => $value];
     }
 
     public function getArray(): array

--- a/src/Configurations/UARules.php
+++ b/src/Configurations/UARules.php
@@ -14,9 +14,7 @@ class UARules implements Configurations
 
     public function addUA(string $value)
     {
-        $object = new \stdClass();
-        $object->target = 'ua';
-        $object->value = $value;
+        $object = (object)['target' => 'ua', 'value' => $value];
 
         array_push($this->configs, $object);
     }

--- a/src/Configurations/UARules.php
+++ b/src/Configurations/UARules.php
@@ -15,7 +15,7 @@ class UARules implements Configurations
     public function addUA(string $value)
     {
         $object = new \stdClass();
-        $object->target = "ua";
+        $object->target = 'ua';
         $object->value = $value;
 
         array_push($this->configs, $object);

--- a/src/Configurations/ZoneLockdown.php
+++ b/src/Configurations/ZoneLockdown.php
@@ -14,18 +14,14 @@ class ZoneLockdown implements Configurations
 
     public function addIP(string $value)
     {
-        $object = new \stdClass();
-        $object->target = 'ip';
-        $object->value = $value;
+        $object = (object)['target' => 'ip', 'value' => $value];
 
         array_push($this->configs, $object);
     }
 
     public function addIPRange(string $value)
     {
-        $object = new \stdClass();
-        $object->target = 'ip_range';
-        $object->value = $value;
+        $object = (object)['target' => 'ip_range', 'value' => $value];
 
         array_push($this->configs, $object);
     }

--- a/src/Configurations/ZoneLockdown.php
+++ b/src/Configurations/ZoneLockdown.php
@@ -14,16 +14,12 @@ class ZoneLockdown implements Configurations
 
     public function addIP(string $value)
     {
-        $object = (object)['target' => 'ip', 'value' => $value];
-
-        array_push($this->configs, $object);
+        $this->configs[] = (object)['target' => 'ip', 'value' => $value];
     }
 
     public function addIPRange(string $value)
     {
-        $object = (object)['target' => 'ip_range', 'value' => $value];
-
-        array_push($this->configs, $object);
+        $this->configs[] = (object)['target' => 'ip_range', 'value' => $value];
     }
 
     public function getArray(): array

--- a/src/Configurations/ZoneLockdown.php
+++ b/src/Configurations/ZoneLockdown.php
@@ -15,7 +15,7 @@ class ZoneLockdown implements Configurations
     public function addIP(string $value)
     {
         $object = new \stdClass();
-        $object->target = "ip";
+        $object->target = 'ip';
         $object->value = $value;
 
         array_push($this->configs, $object);
@@ -24,7 +24,7 @@ class ZoneLockdown implements Configurations
     public function addIPRange(string $value)
     {
         $object = new \stdClass();
-        $object->target = "ip_range";
+        $object->target = 'ip_range';
         $object->value = $value;
 
         array_push($this->configs, $object);

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -62,14 +62,14 @@ class DNS implements API
 
     public function listRecords(
         string $zoneID,
-        string $type = "",
-        string $name = "",
-        string $content = "",
+        string $type = '',
+        string $name = '',
+        string $content = '',
         int $page = 1,
         int $perPage = 20,
-        string $order = "",
-        string $direction = "",
-        string $match = "all"
+        string $order = '',
+        string $direction = '',
+        string $match = 'all'
     ): \stdClass {
         $query = [
             'page' => $page,

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -100,11 +100,7 @@ class DNS implements API
         $user = $this->adapter->get('zones/' . $zoneID . '/dns_records', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function getRecordDetails(string $zoneID, string $recordID): \stdClass

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -115,7 +115,7 @@ class PageRules implements API
     ): bool {
         $options = [];
 
-        if ($active !== null) {
+        if ($target !== null) {
             $options['targets'] = $target->getArray();
         }
 

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -70,19 +70,19 @@ class PageRules implements API
         string $direction = null,
         string $match = null
     ): array {
-        if (is_null($status) && !in_array($status, ['active', 'disabled'])) {
+        if ($status === null && !in_array($status, ['active', 'disabled'])) {
             throw new EndpointException('Page Rules can only be listed by status of active or disabled.');
         }
 
-        if (is_null($order) && !in_array($order, ['status', 'priority'])) {
+        if ($order === null && !in_array($order, ['status', 'priority'])) {
             throw new EndpointException('Page Rules can only be ordered by status or priority.');
         }
 
-        if (is_null($direction) && !in_array($direction, ['asc', 'desc'])) {
+        if ($direction === null && !in_array($direction, ['asc', 'desc'])) {
             throw new EndpointException('Direction of Page Rule ordering can only be asc or desc.');
         }
 
-        if (is_null($match) && !in_array($match, ['all', 'any'])) {
+        if ($match === null && !in_array($match, ['all', 'any'])) {
             throw new EndpointException('Match can only be any or all.');
         }
 

--- a/src/Endpoints/Railgun.php
+++ b/src/Endpoints/Railgun.php
@@ -35,7 +35,7 @@ class Railgun implements API
     public function list(
         int $page = 1,
         int $perPage = 20,
-        string $direction = ""
+        string $direction = ''
     ): \stdClass {
         $query = [
             'page' => $page,

--- a/src/Endpoints/Railgun.php
+++ b/src/Endpoints/Railgun.php
@@ -49,11 +49,7 @@ class Railgun implements API
         $user = $this->adapter->get('railguns', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function get(
@@ -71,11 +67,7 @@ class Railgun implements API
         $user = $this->adapter->get('railguns/' . $railgunID . '/zones', [], []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function update(

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -8,6 +8,7 @@
 
 namespace Cloudflare\API\Endpoints;
 
+use Cloudflare\API\Configurations\Configurations;
 use Cloudflare\API\Adapter\Adapter;
 
 class UARules implements API
@@ -42,7 +43,7 @@ class UARules implements API
     public function createRule(
         string $zoneID,
         string $mode,
-        \Cloudflare\API\Configurations\Configurations $configuration,
+        Configurations $configuration,
         string $ruleID = null,
         string $description = null
     ): bool {

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -69,7 +69,7 @@ class UARules implements API
 
     public function getRuleDetails(string $zoneID, string $blockID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules/' . $blockID, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules/' . $blockID, [], []);
         $body = json_decode($user->getBody());
         return $body->result;
     }

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -33,11 +33,7 @@ class UARules implements API
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function createRule(

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -37,7 +37,7 @@ class User implements API
 
     public function updateUserDetails(array $details): \stdClass
     {
-        $response = $this->adapter->patch("user", [], $details);
+        $response = $this->adapter->patch('user', [], $details);
         return json_decode($response->getBody());
     }
 }

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -27,12 +27,12 @@ class User implements API
 
     public function getUserID(): string
     {
-        return ($this->getUserDetails())->id;
+        return $this->getUserDetails()->id;
     }
 
     public function getUserEmail(): string
     {
-        return ($this->getUserDetails())->email;
+        return $this->getUserDetails()->email;
     }
 
     public function updateUserDetails(array $details): \stdClass

--- a/src/Endpoints/WAF.php
+++ b/src/Endpoints/WAF.php
@@ -23,9 +23,9 @@ class WAF implements \Cloudflare\API\Endpoints\API
         string $zoneID,
         int $page = 1,
         int $perPage = 20,
-        string $order = "",
-        string $direction = "",
-        string $match = "all"
+        string $order = '',
+        string $direction = '',
+        string $match = 'all'
     ): \stdClass {
         $query = [
             'page' => $page,
@@ -67,9 +67,9 @@ class WAF implements \Cloudflare\API\Endpoints\API
         string $packageID,
         int $page = 1,
         int $perPage = 20,
-        string $order = "",
-        string $direction = "",
-        string $match = "all"
+        string $order = '',
+        string $direction = '',
+        string $match = 'all'
     ): \stdClass {
         $query = [
             'page' => $page,
@@ -134,9 +134,9 @@ class WAF implements \Cloudflare\API\Endpoints\API
         string $packageID,
         int $page = 1,
         int $perPage = 20,
-        string $order = "",
-        string $direction = "",
-        string $match = "all"
+        string $order = '',
+        string $direction = '',
+        string $match = 'all'
     ): \stdClass {
         $query = [
             'page' => $page,

--- a/src/Endpoints/WAF.php
+++ b/src/Endpoints/WAF.php
@@ -10,7 +10,7 @@ namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
 
-class WAF implements \Cloudflare\API\Endpoints\API
+class WAF implements API
 {
     private $adapter;
 

--- a/src/Endpoints/WAF.php
+++ b/src/Endpoints/WAF.php
@@ -44,11 +44,7 @@ class WAF implements API
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
 
@@ -87,11 +83,7 @@ class WAF implements API
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function getRuleInfo(
@@ -159,11 +151,7 @@ class WAF implements API
         );
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function getGroupInfo(

--- a/src/Endpoints/ZoneLockdown.php
+++ b/src/Endpoints/ZoneLockdown.php
@@ -32,11 +32,7 @@ class ZoneLockdown implements API
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function createLockdown(

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -35,9 +35,7 @@ class Zones implements API
         ];
 
         if (!empty($organizationID)) {
-            $organization = new \stdClass();
-            $organization->id = $organizationID;
-            $options['organization'] = $organization;
+            $options['organization'] = (object)['id' => $organizationID];
         }
 
         $user = $this->adapter->post('zones', [], $options);
@@ -91,11 +89,7 @@ class Zones implements API
         $user = $this->adapter->get('zones', $query, []);
         $body = json_decode($user->getBody());
 
-        $result = new \stdClass();
-        $result->result = $body->result;
-        $result->result_info = $body->result_info;
-
-        return $result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function getZoneID(string $name = ''): string

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -134,7 +134,7 @@ class Zones implements API
      */
     public function changeDevelopmentMode(string $zoneID, bool $enable = false): bool
     {
-        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', [], ['value' => ($enable ? 'on' : 'off')]);
+        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', [], ['value' => $enable ? 'on' : 'off']);
 
         $body = json_decode($response->getBody());
 

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -37,7 +37,7 @@ class Zones implements API
         if (!empty($organizationID)) {
             $organization = new \stdClass();
             $organization->id = $organizationID;
-            $options["organization"] = $organization;
+            $options['organization'] = $organization;
         }
 
         $user = $this->adapter->post('zones', [], $options);
@@ -58,13 +58,13 @@ class Zones implements API
     }
 
     public function listZones(
-        string $name = "",
-        string $status = "",
+        string $name = '',
+        string $status = '',
         int $page = 1,
         int $perPage = 20,
-        string $order = "",
-        string $direction = "",
-        string $match = "all"
+        string $order = '',
+        string $direction = '',
+        string $match = 'all'
     ): \stdClass {
         $query = [
             'page' => $page,
@@ -98,12 +98,12 @@ class Zones implements API
         return $result;
     }
 
-    public function getZoneID(string $name = ""): string
+    public function getZoneID(string $name = ''): string
     {
         $zones = $this->listZones($name);
 
         if (sizeof($zones->result) < 1) {
-            throw new EndpointException("Could not find zones with specified name.");
+            throw new EndpointException('Could not find zones with specified name.');
         }
 
         return $zones->result[0]->id;
@@ -118,9 +118,9 @@ class Zones implements API
      * @param bool $continuous
      * @return \stdClass
      */
-    public function getAnalyticsDashboard(string $zoneID, string $since = "-10080", string $until = "0", bool $continuous = true): \stdClass
+    public function getAnalyticsDashboard(string $zoneID, string $since = '-10080', string $until = '0', bool $continuous = true): \stdClass
     {
-        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', [], ["since" => $since, "until" => $until, "continuous" => $continuous]);
+        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', [], ['since' => $since, 'until' => $until, 'continuous' => $continuous]);
 
         return json_decode($response->getBody())->result;
     }
@@ -134,7 +134,7 @@ class Zones implements API
      */
     public function changeDevelopmentMode(string $zoneID, bool $enable = false): bool
     {
-        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', [], ["value" => ($enable ? "on" : "off")]);
+        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', [], ['value' => ($enable ? 'on' : 'off')]);
 
         $body = json_decode($response->getBody());
 
@@ -153,7 +153,7 @@ class Zones implements API
      */
     public function cachePurgeEverything(string $zoneID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', [], ["purge_everything" => true]);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', [], ['purge_everything' => true]);
 
         $body = json_decode($user->getBody());
 
@@ -167,7 +167,7 @@ class Zones implements API
     public function cachePurge(string $zoneID, array $files = null, array $tags = null): bool
     {
         if (is_null($files) && is_null($tags)) {
-            throw new EndpointException("No files or tags to purge.");
+            throw new EndpointException('No files or tags to purge.');
         }
 
         $options = [

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -160,7 +160,7 @@ class Zones implements API
 
     public function cachePurge(string $zoneID, array $files = null, array $tags = null): bool
     {
-        if (is_null($files) && is_null($tags)) {
+        if ($files === null && $tags === null) {
             throw new EndpointException('No files or tags to purge.');
         }
 

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -96,7 +96,7 @@ class Zones implements API
     {
         $zones = $this->listZones($name);
 
-        if (sizeof($zones->result) < 1) {
+        if (count($zones->result) < 1) {
             throw new EndpointException('Could not find zones with specified name.');
         }
 

--- a/tests/Adapter/GuzzleTest.php
+++ b/tests/Adapter/GuzzleTest.php
@@ -29,14 +29,14 @@ class GuzzleTest extends TestCase
         $response = $this->client->get('https://httpbin.org/get');
 
         $headers = $response->getHeaders();
-        $this->assertEquals("application/json", $headers["Content-Type"][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Test", $body->headers->{"X-Testing"});
+        $this->assertEquals('Test', $body->headers->{'X-Testing'});
 
         $response = $this->client->get('https://httpbin.org/get', [], ['X-Another-Test' => 'Test2']);
         $body = json_decode($response->getBody());
-        $this->assertEquals("Test2", $body->headers->{"X-Another-Test"});
+        $this->assertEquals('Test2', $body->headers->{'X-Another-Test'});
     }
 
     public function testPost()
@@ -44,10 +44,10 @@ class GuzzleTest extends TestCase
         $response = $this->client->post('https://httpbin.org/post', [], ['X-Post-Test' => 'Testing a POST request.']);
 
         $headers = $response->getHeaders();
-        $this->assertEquals("application/json", $headers["Content-Type"][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a POST request.", $body->json->{"X-Post-Test"});
+        $this->assertEquals('Testing a POST request.', $body->json->{'X-Post-Test'});
     }
 
     public function testPut()
@@ -55,10 +55,10 @@ class GuzzleTest extends TestCase
         $response = $this->client->put('https://httpbin.org/put', [], ['X-Put-Test' => 'Testing a PUT request.']);
 
         $headers = $response->getHeaders();
-        $this->assertEquals("application/json", $headers["Content-Type"][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a PUT request.", $body->json->{"X-Put-Test"});
+        $this->assertEquals('Testing a PUT request.', $body->json->{'X-Put-Test'});
     }
 
     public function testPatch()
@@ -70,10 +70,10 @@ class GuzzleTest extends TestCase
         );
 
         $headers = $response->getHeaders();
-        $this->assertEquals("application/json", $headers["Content-Type"][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a PATCH request.", $body->json->{"X-Patch-Test"});
+        $this->assertEquals('Testing a PATCH request.', $body->json->{'X-Patch-Test'});
     }
 
     public function testDelete()
@@ -85,10 +85,10 @@ class GuzzleTest extends TestCase
         );
 
         $headers = $response->getHeaders();
-        $this->assertEquals("application/json", $headers["Content-Type"][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = json_decode($response->getBody());
-        $this->assertEquals("Testing a DELETE request.", $body->json->{"X-Delete-Test"});
+        $this->assertEquals('Testing a DELETE request.', $body->json->{'X-Delete-Test'});
     }
 
     public function testErrors()

--- a/tests/Auth/APIKeyTest.php
+++ b/tests/Auth/APIKeyTest.php
@@ -18,6 +18,6 @@ class APIKeyTest extends TestCase
         $this->assertEquals('example@example.com', $headers['X-Auth-Email']);
         $this->assertEquals('1234567893feefc5f0q5000bfo0c38d90bbeb', $headers['X-Auth-Key']);
 
-        $this->assertEquals(2, sizeof($headers));
+        $this->assertEquals(2, count($headers));
     }
 }

--- a/tests/Auth/APIKeyTest.php
+++ b/tests/Auth/APIKeyTest.php
@@ -18,6 +18,6 @@ class APIKeyTest extends TestCase
         $this->assertEquals('example@example.com', $headers['X-Auth-Email']);
         $this->assertEquals('1234567893feefc5f0q5000bfo0c38d90bbeb', $headers['X-Auth-Key']);
 
-        $this->assertEquals(2, count($headers));
+        $this->assertCount(2, $headers);
     }
 }

--- a/tests/Auth/NoneTest.php
+++ b/tests/Auth/NoneTest.php
@@ -6,8 +6,6 @@
  * Time: 20:08
  */
 
-use Cloudflare\API\Auth\None;
-
 class NoneTest extends TestCase
 {
     public function testGetHeaders()

--- a/tests/Auth/UserServiceKeyTest.php
+++ b/tests/Auth/UserServiceKeyTest.php
@@ -9,7 +9,7 @@ class UserServiceKeyTest extends TestCase
 {
     public function testGetHeaders()
     {
-        $auth    = new \Cloudflare\API\Auth\UserServiceKey("v1.0-e24fd090c02efcfecb4de8f4ff246fd5c75b48946fdf0ce26c59f91d0d90797b-cfa33fe60e8e34073c149323454383fc9005d25c9b4c502c2f063457ef65322eade065975001a0b4b4c591c5e1bd36a6e8f7e2d4fa8a9ec01c64c041e99530c2-07b9efe0acd78c82c8d9c690aacb8656d81c369246d7f996a205fe3c18e9254a");
+        $auth    = new \Cloudflare\API\Auth\UserServiceKey('v1.0-e24fd090c02efcfecb4de8f4ff246fd5c75b48946fdf0ce26c59f91d0d90797b-cfa33fe60e8e34073c149323454383fc9005d25c9b4c502c2f063457ef65322eade065975001a0b4b4c591c5e1bd36a6e8f7e2d4fa8a9ec01c64c041e99530c2-07b9efe0acd78c82c8d9c690aacb8656d81c369246d7f996a205fe3c18e9254a');
         $headers = $auth->getHeaders();
 
         $this->assertArrayHasKey('X-Auth-User-Service-Key', $headers);

--- a/tests/Auth/UserServiceKeyTest.php
+++ b/tests/Auth/UserServiceKeyTest.php
@@ -19,6 +19,6 @@ class UserServiceKeyTest extends TestCase
             $headers['X-Auth-User-Service-Key']
         );
 
-        $this->assertEquals(1, sizeof($headers));
+        $this->assertEquals(1, count($headers));
     }
 }

--- a/tests/Auth/UserServiceKeyTest.php
+++ b/tests/Auth/UserServiceKeyTest.php
@@ -19,6 +19,6 @@ class UserServiceKeyTest extends TestCase
             $headers['X-Auth-User-Service-Key']
         );
 
-        $this->assertEquals(1, count($headers));
+        $this->assertCount(1, $headers);
     }
 }

--- a/tests/Configurations/ConfigurationsUARulesTest.php
+++ b/tests/Configurations/ConfigurationsUARulesTest.php
@@ -14,7 +14,7 @@ class ConfigurationsUARulesTest extends TestCase
         $configuration->addUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4');
 
         $array = $configuration->getArray();
-        $this->assertEquals(1, sizeof($array));
+        $this->assertEquals(1, count($array));
 
         $this->assertObjectHasAttribute('target', $array[0]);
         $this->assertEquals('ua', $array[0]->target);

--- a/tests/Configurations/ConfigurationsUARulesTest.php
+++ b/tests/Configurations/ConfigurationsUARulesTest.php
@@ -14,7 +14,7 @@ class ConfigurationsUARulesTest extends TestCase
         $configuration->addUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4');
 
         $array = $configuration->getArray();
-        $this->assertEquals(1, count($array));
+        $this->assertCount(1, $array);
 
         $this->assertObjectHasAttribute('target', $array[0]);
         $this->assertEquals('ua', $array[0]->target);

--- a/tests/Configurations/ConfigurationsZoneLockdownTest.php
+++ b/tests/Configurations/ConfigurationsZoneLockdownTest.php
@@ -14,7 +14,7 @@ class ConfigurationsZoneLockdownTest extends TestCase
         $configuration->addIP('1.2.3.4');
 
         $array = $configuration->getArray();
-        $this->assertEquals(1, count($array));
+        $this->assertCount(1, $array);
 
         $this->assertObjectHasAttribute('target', $array[0]);
         $this->assertEquals('ip', $array[0]->target);
@@ -24,7 +24,7 @@ class ConfigurationsZoneLockdownTest extends TestCase
         $configuration->addIPRange('1.2.3.4/24');
 
         $array = $configuration->getArray();
-        $this->assertEquals(2, count($array));
+        $this->assertCount(2, $array);
 
         $this->assertObjectHasAttribute('target', $array[1]);
         $this->assertEquals('ip_range', $array[1]->target);

--- a/tests/Configurations/ConfigurationsZoneLockdownTest.php
+++ b/tests/Configurations/ConfigurationsZoneLockdownTest.php
@@ -6,7 +6,7 @@
  * Date: 05/09/2017
  * Time: 13:50
  */
-class ConfigurationZoneLockdownTest extends TestCase
+class ConfigurationsZoneLockdownTest extends TestCase
 {
     public function testGetArray()
     {

--- a/tests/Configurations/PageRulesTargetTest.php
+++ b/tests/Configurations/PageRulesTargetTest.php
@@ -15,7 +15,7 @@ class PageRulesTargetTest extends TestCase
         $targets = new PageRulesTargets('junade.com/*');
         $array = $targets->getArray();
 
-        $this->assertEquals(1, sizeof($array));
+        $this->assertEquals(1, count($array));
         $this->assertEquals('junade.com/*', $array[0]->constraint->value);
         $this->assertEquals('matches', $array[0]->constraint->operator);
     }

--- a/tests/Configurations/PageRulesTargetTest.php
+++ b/tests/Configurations/PageRulesTargetTest.php
@@ -15,7 +15,7 @@ class PageRulesTargetTest extends TestCase
         $targets = new PageRulesTargets('junade.com/*');
         $array = $targets->getArray();
 
-        $this->assertEquals(1, count($array));
+        $this->assertCount(1, $array);
         $this->assertEquals('junade.com/*', $array[0]->constraint->value);
         $this->assertEquals('matches', $array[0]->constraint->operator);
     }

--- a/tests/Configurations/PageRulesTargetTest.php
+++ b/tests/Configurations/PageRulesTargetTest.php
@@ -16,7 +16,7 @@ class PageRulesTargetTest extends TestCase
         $array = $targets->getArray();
 
         $this->assertEquals(1, sizeof($array));
-        $this->assertEquals("junade.com/*", $array[0]->constraint->value);
-        $this->assertEquals("matches", $array[0]->constraint->operator);
+        $this->assertEquals('junade.com/*', $array[0]->constraint->value);
+        $this->assertEquals('matches', $array[0]->constraint->operator);
     }
 }

--- a/tests/Configurations/ZoneLockdownTest.php
+++ b/tests/Configurations/ZoneLockdownTest.php
@@ -14,7 +14,7 @@ class ConfigurationZoneLockdownTest extends TestCase
         $configuration->addIP('1.2.3.4');
 
         $array = $configuration->getArray();
-        $this->assertEquals(1, sizeof($array));
+        $this->assertEquals(1, count($array));
 
         $this->assertObjectHasAttribute('target', $array[0]);
         $this->assertEquals('ip', $array[0]->target);
@@ -24,7 +24,7 @@ class ConfigurationZoneLockdownTest extends TestCase
         $configuration->addIPRange('1.2.3.4/24');
 
         $array = $configuration->getArray();
-        $this->assertEquals(2, sizeof($array));
+        $this->assertEquals(2, count($array));
 
         $this->assertObjectHasAttribute('target', $array[1]);
         $this->assertEquals('ip_range', $array[1]->target);

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -57,12 +57,12 @@ class DNSTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\DNS($mock);
-        $result = $zones->listRecords("023e105f4ecef8ad9ca31a8372d0c353", "A", "example.com", "127.0.0.1", 1, 20, "type", "desc", "all");
+        $result = $zones->listRecords('023e105f4ecef8ad9ca31a8372d0c353', 'A', 'example.com', '127.0.0.1', 1, 20, 'type', 'desc', 'all');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->result[0]->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -81,9 +81,9 @@ class DNSTest extends TestCase
             );
 
         $dns = new \Cloudflare\API\Endpoints\DNS($mock);
-        $result = $dns->getRecordDetails("023e105f4ecef8ad9ca31a8372d0c353", "372e67954025e0ba6aaa6d586b9e0b59");
+        $result = $dns->getRecordDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
     }
 
     public function testUpdateDNSRecord()
@@ -95,8 +95,8 @@ class DNSTest extends TestCase
 
         $details = [
             'type' => 'A',
-            'name' => "example.com",
-            'content' => "1.2.3.4",
+            'name' => 'example.com',
+            'content' => '1.2.3.4',
             'ttl' => 120,
             'proxied' => false,
         ];
@@ -110,9 +110,9 @@ class DNSTest extends TestCase
             );
 
         $dns = new \Cloudflare\API\Endpoints\DNS($mock);
-        $result = $dns->updateRecordDetails("023e105f4ecef8ad9ca31a8372d0c353", "372e67954025e0ba6aaa6d586b9e0b59", $details);
+        $result = $dns->updateRecordDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59', $details);
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result->id);
 
         foreach ($details as $property => $value) {
             $this->assertEquals($result->result->{ $property }, $value);

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -57,7 +57,7 @@ class DNSTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\DNS($mock);
-        $result = $zones->listRecords('023e105f4ecef8ad9ca31a8372d0c353', 'A', 'example.com', '127.0.0.1', 1, 20, 'type', 'desc', 'all');
+        $result = $zones->listRecords('023e105f4ecef8ad9ca31a8372d0c353', 'A', 'example.com', '127.0.0.1', 1, 20, 'type', 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);

--- a/tests/Endpoints/IPsTest.php
+++ b/tests/Endpoints/IPsTest.php
@@ -6,8 +6,6 @@
  * Time: 20:16
  */
 
-use Cloudflare\API\Endpoints\IPs;
-
 class IPsTest extends TestCase
 {
     public function testListIPs()

--- a/tests/Endpoints/IPsTest.php
+++ b/tests/Endpoints/IPsTest.php
@@ -26,7 +26,7 @@ class IPsTest extends TestCase
 
         $ips = new \Cloudflare\API\Endpoints\IPs($mock);
         $ips = $ips->listIPs();
-        $this->assertObjectHasAttribute("ipv4_cidrs", $ips);
-        $this->assertObjectHasAttribute("ipv6_cidrs", $ips);
+        $this->assertObjectHasAttribute('ipv4_cidrs', $ips);
+        $this->assertObjectHasAttribute('ipv6_cidrs', $ips);
     }
 }

--- a/tests/Endpoints/PageRulesTest.php
+++ b/tests/Endpoints/PageRulesTest.php
@@ -6,8 +6,6 @@
  * Time: 19:25
  */
 
-use Cloudflare\API\Adapter\PageRules;
-
 class PageRulesTest extends TestCase
 {
     public function testCreatePageRule()

--- a/tests/Endpoints/RailgunTest.php
+++ b/tests/Endpoints/RailgunTest.php
@@ -6,8 +6,6 @@
  * Time: 11:20
  */
 
-use Cloudflare\API\Endpoints\Railgun;
-
 class RailgunTest extends TestCase
 {
     public function testcreate()

--- a/tests/Endpoints/RailgunTest.php
+++ b/tests/Endpoints/RailgunTest.php
@@ -13,7 +13,7 @@ class RailgunTest extends TestCase
     public function testcreate()
     {
         $details = [
-            'name' => "My Railgun",
+            'name' => 'My Railgun',
         ];
 
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/createRailgun.json');
@@ -59,7 +59,7 @@ class RailgunTest extends TestCase
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
-        $result = $railgun->list(1, 20, "desc");
+        $result = $railgun->list(1, 20, 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
@@ -80,9 +80,9 @@ class RailgunTest extends TestCase
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
-        $result = $railgun->get("e928d310693a83094309acf9ead50448");
+        $result = $railgun->get('e928d310693a83094309acf9ead50448');
 
-        $this->assertEquals("e928d310693a83094309acf9ead50448", $result->id);
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $result->id);
     }
 
     public function testgetZones()
@@ -101,7 +101,7 @@ class RailgunTest extends TestCase
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
-        $result = $railgun->getZones("e928d310693a83094309acf9ead50448");
+        $result = $railgun->getZones('e928d310693a83094309acf9ead50448');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
@@ -127,9 +127,9 @@ class RailgunTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\Railgun($mock);
-        $result = $waf->update("e928d310693a83094309acf9ead50448", true);
+        $result = $waf->update('e928d310693a83094309acf9ead50448', true);
 
-        $this->assertEquals("e928d310693a83094309acf9ead50448", $result->id);
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $result->id);
     }
 
     public function testdelete()
@@ -148,6 +148,6 @@ class RailgunTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\Railgun($mock);
-        $waf->delete("e928d310693a83094309acf9ead50448");
+        $waf->delete('e928d310693a83094309acf9ead50448');
     }
 }

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -27,7 +27,7 @@ class UARulesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\UARules($mock);
-        $result = $zones->listRules('023e105f4ecef8ad9ca31a8372d0c353', 1, 20);
+        $result = $zones->listRules('023e105f4ecef8ad9ca31a8372d0c353');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -27,12 +27,12 @@ class UARulesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\UARules($mock);
-        $result = $zones->listRules("023e105f4ecef8ad9ca31a8372d0c353", 1, 20);
+        $result = $zones->listRules('023e105f4ecef8ad9ca31a8372d0c353', 1, 20);
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->result[0]->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -84,9 +84,9 @@ class UARulesTest extends TestCase
             );
 
         $lockdown = new \Cloudflare\API\Endpoints\UARules($mock);
-        $result = $lockdown->getRuleDetails("023e105f4ecef8ad9ca31a8372d0c353", "372e67954025e0ba6aaa6d586b9e0b59");
+        $result = $lockdown->getRuleDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
     }
 
     public function testUpdateRule()

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -17,10 +17,10 @@ class UserTest extends TestCase
         $user = new \Cloudflare\API\Endpoints\User($mock);
         $details = $user->getUserDetails();
 
-        $this->assertObjectHasAttribute("id", $details);
-        $this->assertEquals("7c5dae5552338874e5053f2534d2767a", $details->id);
-        $this->assertObjectHasAttribute("email", $details);
-        $this->assertEquals("user@example.com", $details->email);
+        $this->assertObjectHasAttribute('id', $details);
+        $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $details->id);
+        $this->assertObjectHasAttribute('email', $details);
+        $this->assertEquals('user@example.com', $details->email);
     }
 
     public function testGetUserID()
@@ -31,7 +31,7 @@ class UserTest extends TestCase
         $mock->method('get')->willReturn($response);
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
-        $this->assertEquals("7c5dae5552338874e5053f2534d2767a", $user->getUserID());
+        $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $user->getUserID());
     }
 
     public function testGetUserEmail()
@@ -44,7 +44,7 @@ class UserTest extends TestCase
         $mock->expects($this->once())->method('get');
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
-        $this->assertEquals("user@example.com", $user->getUserEmail());
+        $this->assertEquals('user@example.com', $user->getUserEmail());
     }
 
     public function testUpdateUserDetails()
@@ -59,6 +59,6 @@ class UserTest extends TestCase
             ->with($this->equalTo('user'), $this->equalTo([]), $this->equalTo(['email' => 'user2@example.com']));
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
-        $user->updateUserDetails(['email' => "user2@example.com"]);
+        $user->updateUserDetails(['email' => 'user2@example.com']);
     }
 }

--- a/tests/Endpoints/WAFTest.php
+++ b/tests/Endpoints/WAFTest.php
@@ -6,8 +6,6 @@
  * Time: 13:34
  */
 
-use Cloudflare\API\Endpoints\WAF;
-
 class WAFTest extends TestCase
 {
     public function testgetPackages()

--- a/tests/Endpoints/WAFTest.php
+++ b/tests/Endpoints/WAFTest.php
@@ -32,12 +32,12 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getPackages("023e105f4ecef8ad9ca31a8372d0c353", 1, 20, "status", "desc", "all");
+        $result = $waf->getPackages('023e105f4ecef8ad9ca31a8372d0c353', 1, 20, 'status', 'desc', 'all');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("a25a9a7e9c00afc1fb2e0245519d725b", $result->result[0]->id);
+        $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -56,9 +56,9 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getPackageInfo("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b");
+        $result = $waf->getPackageInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b');
 
-        $this->assertEquals("a25a9a7e9c00afc1fb2e0245519d725b", $result->id);
+        $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $result->id);
     }
 
     public function testgetRules()
@@ -83,12 +83,12 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getRules("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", 1, 20, "status", "desc", "all");
+        $result = $waf->getRules('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc', 'all');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("92f17202ed8bd63d69a66b86a49a8f6b", $result->result[0]->id);
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -107,9 +107,9 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getRuleInfo("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", "f939de3be84e66e757adcdcb87908023");
+        $result = $waf->getRuleInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'f939de3be84e66e757adcdcb87908023');
 
-        $this->assertEquals("f939de3be84e66e757adcdcb87908023", $result->id);
+        $this->assertEquals('f939de3be84e66e757adcdcb87908023', $result->id);
     }
 
     public function testupdateRule()
@@ -120,7 +120,7 @@ class WAFTest extends TestCase
         $mock->method('patch')->willReturn($response);
 
         $details = [
-            'mode' => "on",
+            'mode' => 'on',
         ];
 
         $mock->expects($this->once())
@@ -132,9 +132,9 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->updateRule("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", "f939de3be84e66e757adcdcb87908023", "on");
+        $result = $waf->updateRule('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'f939de3be84e66e757adcdcb87908023', 'on');
 
-        $this->assertEquals("f939de3be84e66e757adcdcb87908023", $result->id);
+        $this->assertEquals('f939de3be84e66e757adcdcb87908023', $result->id);
 
         foreach ($details as $property => $value) {
             $this->assertEquals($result->{ $property }, $value);
@@ -163,12 +163,12 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getGroups("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", 1, 20, "status", "desc", "all");
+        $result = $waf->getGroups('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc', 'all');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("de677e5818985db1285d0e80225f06e5", $result->result[0]->id);
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -187,9 +187,9 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getGroupInfo("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", "de677e5818985db1285d0e80225f06e5");
+        $result = $waf->getGroupInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'de677e5818985db1285d0e80225f06e5');
 
-        $this->assertEquals("de677e5818985db1285d0e80225f06e5", $result->id);
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $result->id);
     }
 
     public function testupdateGroup()
@@ -200,7 +200,7 @@ class WAFTest extends TestCase
         $mock->method('patch')->willReturn($response);
 
         $details = [
-            'mode' => "off",
+            'mode' => 'off',
         ];
 
         $mock->expects($this->once())
@@ -212,9 +212,9 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->updateGroup("023e105f4ecef8ad9ca31a8372d0c353", "a25a9a7e9c00afc1fb2e0245519d725b", "de677e5818985db1285d0e80225f06e5", "off");
+        $result = $waf->updateGroup('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'de677e5818985db1285d0e80225f06e5', 'off');
 
-        $this->assertEquals("de677e5818985db1285d0e80225f06e5", $result->id);
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $result->id);
 
         foreach ($details as $property => $value) {
             $this->assertEquals($result->{ $property }, $value);

--- a/tests/Endpoints/WAFTest.php
+++ b/tests/Endpoints/WAFTest.php
@@ -32,7 +32,7 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getPackages('023e105f4ecef8ad9ca31a8372d0c353', 1, 20, 'status', 'desc', 'all');
+        $result = $waf->getPackages('023e105f4ecef8ad9ca31a8372d0c353', 1, 20, 'status', 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
@@ -83,7 +83,7 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getRules('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc', 'all');
+        $result = $waf->getRules('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
@@ -163,7 +163,7 @@ class WAFTest extends TestCase
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
-        $result = $waf->getGroups('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc', 'all');
+        $result = $waf->getGroups('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 1, 20, 'status', 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -27,12 +27,12 @@ class ZoneLockdownTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
-        $result = $zones->listLockdowns("023e105f4ecef8ad9ca31a8372d0c353", 1, 20);
+        $result = $zones->listLockdowns('023e105f4ecef8ad9ca31a8372d0c353', 1, 20);
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->result[0]->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -52,7 +52,7 @@ class ZoneLockdownTest extends TestCase
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns'),
                 $this->equalTo([]),
                 $this->equalTo([
-                    'urls' => ["api.mysite.com/some/endpoint*"],
+                    'urls' => ['api.mysite.com/some/endpoint*'],
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
                     'description' => 'Restrict access to these endpoints to requests from a known IP address',
                     'configurations' => $config->getArray(),
@@ -62,7 +62,7 @@ class ZoneLockdownTest extends TestCase
         $zoneLockdown = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
         $zoneLockdown->createLockdown(
             '023e105f4ecef8ad9ca31a8372d0c353',
-            ["api.mysite.com/some/endpoint*"],
+            ['api.mysite.com/some/endpoint*'],
             $config,
             '372e67954025e0ba6aaa6d586b9e0b59',
             'Restrict access to these endpoints to requests from a known IP address'
@@ -84,9 +84,9 @@ class ZoneLockdownTest extends TestCase
             );
 
         $lockdown = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
-        $result = $lockdown->getLockdownDetails("023e105f4ecef8ad9ca31a8372d0c353", "372e67954025e0ba6aaa6d586b9e0b59");
+        $result = $lockdown->getLockdownDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
-        $this->assertEquals("372e67954025e0ba6aaa6d586b9e0b59", $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
     }
 
     public function testUpdateLockdown()
@@ -105,7 +105,7 @@ class ZoneLockdownTest extends TestCase
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59'),
                 $this->equalTo([]),
                 $this->equalTo([
-                    'urls' => ["api.mysite.com/some/endpoint*"],
+                    'urls' => ['api.mysite.com/some/endpoint*'],
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
                     'description' => 'Restrict access to these endpoints to requests from a known IP address',
                     'configurations' => $config->getArray(),
@@ -116,7 +116,7 @@ class ZoneLockdownTest extends TestCase
         $zoneLockdown->updateLockdown(
             '023e105f4ecef8ad9ca31a8372d0c353',
             '372e67954025e0ba6aaa6d586b9e0b59',
-            ["api.mysite.com/some/endpoint*"],
+            ['api.mysite.com/some/endpoint*'],
             $config,
             'Restrict access to these endpoints to requests from a known IP address'
         );

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -27,7 +27,7 @@ class ZoneLockdownTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
-        $result = $zones->listLockdowns('023e105f4ecef8ad9ca31a8372d0c353', 1, 20);
+        $result = $zones->listLockdowns('023e105f4ecef8ad9ca31a8372d0c353');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -95,7 +95,7 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->listZones('example.com', 'active', 1, 20, 'status', 'desc', 'all');
+        $result = $zones->listZones('example.com', 'active', 1, 20, 'status', 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -34,15 +34,16 @@ class ZonesTest extends TestCase
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
-        $org = new stdClass();
-        $org->id = '01a7362d577a6c3019a474fd6f485823';
-
         $mock->expects($this->once())
             ->method('post')
             ->with(
                 $this->equalTo('zones'),
                 $this->equalTo([]),
-                $this->equalTo(['name' => 'example.com', 'jumpstart' => true, 'organization' => $org])
+                $this->equalTo([
+                    'name' => 'example.com',
+                    'jumpstart' => true,
+                    'organization' => (object)['id' => '01a7362d577a6c3019a474fd6f485823']
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -24,10 +24,10 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->addZone("example.com");
+        $result = $zones->addZone('example.com');
 
-        $this->assertObjectHasAttribute("id", $result);
-        $this->assertEquals("023e105f4ecef8ad9ca31a8372d0c353", $result->id);
+        $this->assertObjectHasAttribute('id', $result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result->id);
 
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/createPageRule.json');
 
@@ -35,7 +35,7 @@ class ZonesTest extends TestCase
         $mock->method('post')->willReturn($response);
 
         $org = new stdClass();
-        $org->id = "01a7362d577a6c3019a474fd6f485823";
+        $org->id = '01a7362d577a6c3019a474fd6f485823';
 
         $mock->expects($this->once())
             ->method('post')
@@ -46,7 +46,7 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $zones->addZone("example.com", true, "01a7362d577a6c3019a474fd6f485823");
+        $zones->addZone('example.com', true, '01a7362d577a6c3019a474fd6f485823');
     }
 
     public function testActivationTest()
@@ -65,7 +65,7 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->activationCheck("c2547eb745079dac9320b638f5e225cf483cc5cfdda41");
+        $result = $zones->activationCheck('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
 
         $this->assertTrue($result);
     }
@@ -94,12 +94,12 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->listZones("example.com", "active", 1, 20, "status", "desc", "all");
+        $result = $zones->listZones('example.com', 'active', 1, 20, 'status', 'desc', 'all');
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
 
-        $this->assertEquals("023e105f4ecef8ad9ca31a8372d0c353", $result->result[0]->id);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
     }
 
@@ -124,9 +124,9 @@ class ZonesTest extends TestCase
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->getZoneID("example.com");
+        $result = $zones->getZoneID('example.com');
 
-        $this->assertEquals("023e105f4ecef8ad9ca31a8372d0c353", $result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result);
     }
 
     public function testGetAnalyticsDashboard()
@@ -141,14 +141,14 @@ class ZonesTest extends TestCase
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/analytics/dashboard'),
                 $this->equalTo([]),
-                $this->equalTo(["since" => "-10080", "until" => "0", "continuous" => true])
+                $this->equalTo(['since' => '-10080', 'until' => '0', 'continuous' => true])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $analytics = $zones->getAnalyticsDashboard("c2547eb745079dac9320b638f5e225cf483cc5cfdda41");
+        $analytics = $zones->getAnalyticsDashboard('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
 
-        $this->assertObjectHasAttribute("since", $analytics->totals);
-        $this->assertObjectHasAttribute("since", $analytics->timeseries[0]);
+        $this->assertObjectHasAttribute('since', $analytics->totals);
+        $this->assertObjectHasAttribute('since', $analytics->timeseries[0]);
     }
     
     public function testChangeDevelopmentMode()
@@ -163,11 +163,11 @@ class ZonesTest extends TestCase
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/settings/development_mode'),
                 $this->equalTo([]),
-                $this->equalTo(["value" => "on"])
+                $this->equalTo(['value' => 'on'])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->changeDevelopmentMode("c2547eb745079dac9320b638f5e225cf483cc5cfdda41", true);
+        $result = $zones->changeDevelopmentMode('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', true);
 
         $this->assertTrue($result);
     }
@@ -184,11 +184,11 @@ class ZonesTest extends TestCase
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
                 $this->equalTo([]),
-                $this->equalTo(["purge_everything" => true])
+                $this->equalTo(['purge_everything' => true])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
-        $result = $zones->cachePurgeEverything("c2547eb745079dac9320b638f5e225cf483cc5cfdda41");
+        $result = $zones->cachePurgeEverything('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
 
         $this->assertTrue($result);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      * Returns a PSR7 Stream for a given fixture.
      *
      * @param  string     $fixture The fixture to create the stream for.
-     * @return Psr7Stream
+     * @return Psr7\Stream
      */
     protected function getPsr7StreamForFixture($fixture): Psr7\Stream
     {
@@ -31,7 +31,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      *
      * @param  string        $fixture    The fixture to create the response for.
      * @param  integer       $statusCode A HTTP Status Code for the response.
-     * @return Psr7Response
+     * @return Psr7\Response
      */
     protected function getPsr7JsonResponseForFixture($fixture, $statusCode = 200): Psr7\Response
     {


### PR DESCRIPTION
This PR resolves and cleans a few things. Including:

**Unify code style:**
- Remove unnecessary double quotes (_I can revert this, if you want. The changeset is somewhat big_ 😅).
- Shorten the fully qualified class names.
- Remove redundant parentheses.
- Switch from ` new \stdClass()` to object casting.

**Control flow:**
- Fix loop which doesn't loop.

**Language level migration:**
- All `is_null(...)` calls can be safely replaced with `null === ...` constructs.
- `sizeof(...)` is an alias function. Use `count(...)` instead.

**Performance:**
- Use `$array[] = ...` instead of `array_push(...)`.

**Parameter type:**
- Required parameter type is missing.

**PHPDoc:**
- Argument PHPDoc missing.
- Return type doesn't match.

**Bugs:**
- Fix null pointer exception.
- Class autoloading correctness (file and class name are not identical).

**PHPUnit:**
- `assertCount` should be used instead.

**Unused:**
- Remove arguments which can be safely dropped, as they are identical to the default value.
- Remove unused imports.

**Things that should be considered:**
Instead of a `Makefile` you might look at composer scripts. Something like this:
```json
"scripts": {
    "fix": [
        "php-cs-fixer . fix --config=.php_cs"
    ],
    "lint": [
        "php-cs-fixer . fix --config=.php_cs --dry-run",
        "phpmd src/ text cleancode,codesize,controversial,design,naming,unusedcode",
        "phpmd tests/ text cleancode,codesize,controversial,design,naming,unusedcode"
    ],
    "test": [
        "phpunit --configuration phpunit.xml"
    ]
},
```
This because Linux makefiles doesn't work for Windows users.