### PR TITLE
Change isset to empty to remove false positives

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -121,7 +121,7 @@ class Guzzle implements Adapter
             throw new JSONException();
         }
 
-        if (isset($json->errors)) {
+        if (!empty($json->errors)) {
             throw new ResponseException($json->errors[0]->message, $json->errors[0]->code);
         }
 


### PR DESCRIPTION
When the library is checking for errors, it uses an isset call rather than empty.
The cloudflare API provides back to me the following as part of the response
```
  ["success"]=>
  bool(true)
  ["errors"]=>
  array(0) {
  }
}
```

Unfortunately, with this, `isset($json->errors)` evaluates to true and throws an error. By changing this to `!empty($json->errors)` we protect against false positives.