### PR TITLE
AnalyticsDashboard params are not headers

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -114,7 +114,7 @@ class Zones implements API
      */
     public function getAnalyticsDashboard(string $zoneID, string $since = '-10080', string $until = '0', bool $continuous = true): \stdClass
     {
-        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', [], ['since' => $since, 'until' => $until, 'continuous' => $continuous]);
+        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', ['since' => $since, 'until' => $until, 'continuous' => var_export($continuous, true)], []);
 
         return json_decode($response->getBody())->result;
     }

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -141,8 +141,8 @@ class ZonesTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/analytics/dashboard'),
-                $this->equalTo([]),
-                $this->equalTo(['since' => '-10080', 'until' => '0', 'continuous' => true])
+                $this->equalTo(['since' => '-10080', 'until' => '0', 'continuous' => var_export(true, true)]),
+                $this->equalTo([])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);


### PR DESCRIPTION
Also 'continuous' needs to be a string for the API to process it.