### PR TITLE
Fix name of jumpstart zone add option to jump_start

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -27,11 +27,11 @@ class Zones implements API
      * @param string $organizationID
      * @return \stdClass
      */
-    public function addZone(string $name, bool $jump_start = false, string $organizationID = ''): \stdClass
+    public function addZone(string $name, bool $jumpStart = false, string $organizationID = ''): \stdClass
     {
         $options = [
             'name' => $name,
-            'jump_start' => $jump_start
+            'jump_start' => $jumpStart
         ];
 
         if (!empty($organizationID)) {

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -23,7 +23,7 @@ class Zones implements API
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      *
      * @param string $name
-     * @param bool $jump_start
+     * @param bool $jumpStart
      * @param string $organizationID
      * @return \stdClass
      */

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -23,15 +23,15 @@ class Zones implements API
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      *
      * @param string $name
-     * @param bool $jumpstart
+     * @param bool $jump_start
      * @param string $organizationID
      * @return \stdClass
      */
-    public function addZone(string $name, bool $jumpstart = false, string $organizationID = ''): \stdClass
+    public function addZone(string $name, bool $jump_start = false, string $organizationID = ''): \stdClass
     {
         $options = [
             'name' => $name,
-            'jumpstart' => $jumpstart
+            'jump_start' => $jump_start
         ];
 
         if (!empty($organizationID)) {

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -20,7 +20,7 @@ class ZonesTest extends TestCase
             ->with(
                 $this->equalTo('zones'),
                 $this->equalTo([]),
-                $this->equalTo(['name' => 'example.com', 'jumpstart' => false])
+                $this->equalTo(['name' => 'example.com', 'jump_start' => false])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
@@ -41,7 +41,7 @@ class ZonesTest extends TestCase
                 $this->equalTo([]),
                 $this->equalTo([
                     'name' => 'example.com',
-                    'jumpstart' => true,
+                    'jump_start' => true,
                     'organization' => (object)['id' => '01a7362d577a6c3019a474fd6f485823']
                 ])
             );


### PR DESCRIPTION
The existing option causes the Cloudflare API to ignore the "jumpstart" parameter as it is incorrect. This renames it the correct name of "jump_start"

API documentation here shows the parameter is named "jump_start" not "jumpstart" as used in the SDK: https://api.cloudflare.com/#zone-create-a-zone