### PR TITLE
Update DNS.php to store a created record's ID

### DIFF
--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -13,10 +13,22 @@ use Cloudflare\API\Adapter\Adapter;
 class DNS implements API
 {
     private $adapter;
+    private $record_id = false;
 
     public function __construct(Adapter $adapter)
     {
         $this->adapter = $adapter;
+    }
+
+    /**
+     * Return the $record_id value. Could be a string or boolean false so
+     * no return type declaration can be made. Will be set by addRecord()
+     * on successful creation of a record.
+     * @return string|bool
+     */
+    public function getRecordID()
+    {
+        return $this->record_id;
     }
 
     /**
@@ -54,6 +66,7 @@ class DNS implements API
         $body = json_decode($user->getBody());
 
         if (isset($body->result->id)) {
+            $this->record_id = $body->result->id;
             return true;
         }
 


### PR DESCRIPTION
Creating a DNS record using `DNS::addRecord()` returns a boolean value, however, subsequent API calls to interact with said record require you to use the record's ID. Seemingly the only way to acquire the ID after creation is to call `DNS::listRecords()`, loop through the response and extract the record data using the known record name as an identifier.

Unless I'm misinterpreting the SDK, this seems inefficient seeing as `DNS::addRecord()` does actually have the record ID, but doesn't do anything with it, just returns a boolean based on its existence:
```
$body = json_decode($user->getBody());

if (isset($body->result->id)) {
    return true;
}

return false;
```

Seeing as the API does not support requesting a record by it's name, the only solution I can see (although I'm sure there's more) would be to store or return the ID from `DNS::addRecord()`. Until a future PHP version allows multiple type declarations (`bool|string`) we have to use one declaration and returning the ID from `addRecord()` would break the nice, modern `bool` declaration used. Instead the ID is written to the class and a new `getRecordID()` method gives us access to it later.