### PR TITLE
Nest payload for forwarding_url page rule action in value block

### DIFF
--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -133,8 +133,10 @@ class PageRulesActions implements Configurations
         }
 
         $this->addConfigurationOption("forwarding_url", [
-            'status_code' => $statusCode,
-            'url' => $forwardingUrl,
+            'value' => [
+                'status_code' => $statusCode,
+                'url' => $forwardingUrl,
+            ],
         ]);
     }
 
@@ -299,9 +301,19 @@ class PageRulesActions implements Configurations
 
     private function addConfigurationOption(string $setting, array $configuration)
     {
+        /**
+         * Transforms an, optionally nested, array in to a collection of
+         * stdClass objects.
+         *
+         * @var array $array
+         */
+        $getArrayAsObject = function (array $array) {
+            return json_decode(json_encode($array));
+        };
+
         $configuration['id'] = $setting;
 
-        array_push($this->configs, (object) $configuration);
+        array_push($this->configs, $getArrayAsObject($configuration));
     }
 
     private function getBoolAsOnOrOff(bool $value): string

--- a/tests/Configurations/PageRulesActionTest.php
+++ b/tests/Configurations/PageRulesActionTest.php
@@ -1,0 +1,21 @@
+<?php
+use Cloudflare\API\Configurations\PageRulesActions;
+
+class PageRulesActionTest extends TestCase
+{
+    public function testForwardingURLConfigurationIsApplied()
+    {
+        $identifier = 'forwarding_url';
+        $statusCode = 301;
+        $forwardingURL = 'https://www.example.org/';
+
+        $actions = new PageRulesActions();
+        $actions->setForwardingURL($statusCode, $forwardingURL);
+        $configuration = $actions->getArray();
+
+        $this->assertCount(1, $configuration);
+        $this->assertEquals($identifier, $configuration[0]->id);
+        $this->assertEquals($statusCode, $configuration[0]->value->status_code);
+        $this->assertEquals($forwardingURL, $configuration[0]->value->url);
+    }
+}


### PR DESCRIPTION
This fixes #46 by using `value` to key the forwarding_url page rule action configuration.