### PR TITLE
Cleanup, refactoring, and removal of duplicate code

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -31,46 +31,46 @@ interface Adapter
      * RFCs, it is never useful).
      *
      * @param string $uri
-     * @param array $query
+     * @param array $data
      * @param array $headers
      *
      * @return mixed
      */
-    public function get(string $uri, array $query, array $headers): ResponseInterface;
+    public function get(string $uri, array $data = [], array $headers = []): ResponseInterface;
 
     /**
      * @param string $uri
+     * @param array $data
      * @param array $headers
-     * @param array $body
      *
      * @return mixed
      */
-    public function post(string $uri, array $headers, array $body): ResponseInterface;
+    public function post(string $uri, array $data = [], array $headers = []): ResponseInterface;
 
     /**
      * @param string $uri
+     * @param array $data
      * @param array $headers
-     * @param array $body
      *
      * @return mixed
      */
-    public function put(string $uri, array $headers, array $body): ResponseInterface;
+    public function put(string $uri, array $data = [], array $headers = []): ResponseInterface;
 
     /**
      * @param string $uri
+     * @param array $data
      * @param array $headers
-     * @param array $body
      *
      * @return mixed
      */
-    public function patch(string $uri, array $headers, array $body): ResponseInterface;
+    public function patch(string $uri, array $data = [], array $headers = []): ResponseInterface;
 
     /**
      * @param string $uri
+     * @param array $data
      * @param array $headers
-     * @param array $body
      *
      * @return mixed
      */
-    public function delete(string $uri, array $headers, array $body): ResponseInterface;
+    public function delete(string $uri, array $data = [], array $headers = []): ResponseInterface;
 }

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -37,79 +37,56 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function get(string $uri, array $query = [], array $headers = []): ResponseInterface
+    public function get(string $uri, array $data = [], array $headers = []): ResponseInterface
     {
-        $response = $this->client->get($uri, ['query' => $query, 'headers' => $headers]);
-
-        $this->checkError($response);
-        return $response;
+        return $this->request('get', $uri, $data, $headers);
     }
 
     /**
      * @inheritDoc
      */
-    public function post(string $uri, array $headers = [], array $body = []): ResponseInterface
+    public function post(string $uri, array $data = [], array $headers = []): ResponseInterface
     {
-        $response = $this->client->post(
-            $uri,
-            [
-                'headers' => $headers,
-                'json' => $body
-            ]
-        );
-
-        $this->checkError($response);
-        return $response;
+        return $this->request('post', $uri, $data, $headers);
     }
 
     /**
      * @inheritDoc
      */
-    public function put(string $uri, array $headers = [], array $body = []): ResponseInterface
+    public function put(string $uri, array $data = [], array $headers = []): ResponseInterface
     {
-        $response = $this->client->put(
-            $uri,
-            [
-                'headers' => $headers,
-                'json' => $body
-            ]
-        );
-
-        $this->checkError($response);
-        return $response;
+        return $this->request('put', $uri, $data, $headers);
     }
 
     /**
      * @inheritDoc
      */
-    public function patch(string $uri, array $headers = [], array $body = []): ResponseInterface
+    public function patch(string $uri, array $data = [], array $headers = []): ResponseInterface
     {
-        $response = $this->client->patch(
-            $uri,
-            [
-                'headers' => $headers,
-                'json' => $body
-            ]
-        );
-
-        $this->checkError($response);
-        return $response;
+        return $this->request('patch', $uri, $data, $headers);
     }
 
     /**
      * @inheritDoc
      */
-    public function delete(string $uri, array $headers = [], array $body = []): ResponseInterface
+    public function delete(string $uri, array $data = [], array $headers = []): ResponseInterface
     {
-        $response = $this->client->delete(
-            $uri,
-            [
-                'headers' => $headers,
-                'json' => $body
-            ]
-        );
+        return $this->request('delete', $uri, $data, $headers);
+    }
+
+    public function request(string $method, string $uri, array $data = [], array $headers = [])
+    {
+        if (!in_array($method, ['get', 'post', 'put', 'patch', 'delete'])) {
+            throw new \InvalidArgumentException('Request method must be get, post, put, patch, or delete');
+        }
+
+        $response = $this->client->$method($uri, [
+            'headers' => $headers,
+            ($method === 'get' ? 'query' : 'json') => $data,
+        ]);
 
         $this->checkError($response);
+
         return $response;
     }
 

--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -301,19 +301,9 @@ class PageRulesActions implements Configurations
 
     private function addConfigurationOption(string $setting, array $configuration)
     {
-        /**
-         * Transforms an, optionally nested, array in to a collection of
-         * stdClass objects.
-         *
-         * @var array $array
-         */
-        $getArrayAsObject = function (array $array) {
-            return json_decode(json_encode($array));
-        };
-
         $configuration['id'] = $setting;
 
-        array_push($this->configs, $getArrayAsObject($configuration));
+        array_push($this->configs, $configuration);
     }
 
     private function getBoolAsOnOrOff(bool $value): string

--- a/src/Configurations/PageRulesTargets.php
+++ b/src/Configurations/PageRulesTargets.php
@@ -15,9 +15,9 @@ class PageRulesTargets implements Configurations
     public function __construct(string $queryUrl)
     {
         $this->targets = [
-            (object)[
+            [
                 'target' => 'url',
-                'constraint' => (object)[
+                'constraint' => [
                     'operator' => 'matches',
                     'value' => $queryUrl
                 ]

--- a/src/Configurations/UARules.php
+++ b/src/Configurations/UARules.php
@@ -14,7 +14,7 @@ class UARules implements Configurations
 
     public function addUA(string $value)
     {
-        $this->configs[] = (object)['target' => 'ua', 'value' => $value];
+        $this->configs[] = ['target' => 'ua', 'value' => $value];
     }
 
     public function getArray(): array

--- a/src/Configurations/ZoneLockdown.php
+++ b/src/Configurations/ZoneLockdown.php
@@ -14,12 +14,12 @@ class ZoneLockdown implements Configurations
 
     public function addIP(string $value)
     {
-        $this->configs[] = (object)['target' => 'ip', 'value' => $value];
+        $this->configs[] = ['target' => 'ip', 'value' => $value];
     }
 
     public function addIPRange(string $value)
     {
-        $this->configs[] = (object)['target' => 'ip_range', 'value' => $value];
+        $this->configs[] = ['target' => 'ip_range', 'value' => $value];
     }
 
     public function getArray(): array

--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -77,7 +77,7 @@ class AccessRules implements API
             $query['notes'] = $notes;
         }
 
-        $data = $this->adapter->get('zones/' . $zoneID . '/firewall/access_rules/rules', $query, []);
+        $data = $this->adapter->get('zones/' . $zoneID . '/firewall/access_rules/rules', $query);
         $body = json_decode($data->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -91,14 +91,14 @@ class AccessRules implements API
     ): bool {
         $options = [
             'mode' => $mode,
-            'configuration' => (object) $configuration->getArray()
+            'configuration' => $configuration->getArray()
         ];
 
         if ($notes !== null) {
             $options['notes'] = $notes;
         }
 
-        $query = $this->adapter->post('zones/' . $zoneID . '/firewall/access_rules/rules', [], $options);
+        $query = $this->adapter->post('zones/' . $zoneID . '/firewall/access_rules/rules', $options);
 
         $body = json_decode($query->getBody());
 
@@ -123,7 +123,7 @@ class AccessRules implements API
             $options['notes'] = $notes;
         }
 
-        $query = $this->adapter->patch('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, [], $options);
+        $query = $this->adapter->patch('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, $options);
 
         $body = json_decode($query->getBody());
 
@@ -140,7 +140,7 @@ class AccessRules implements API
             'cascade' => $cascade
         ];
 
-        $data = $this->adapter->delete('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, [], $options);
+        $data = $this->adapter->delete('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, $options);
 
         $body = json_decode($data->getBody());
 

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -33,13 +33,13 @@ class CustomHostnames implements API
     {
         $options = [
             'hostname' => $hostname,
-            'ssl' => (object)[
+            'ssl' => [
                 'method' => $sslMethod,
                 'type' => $sslType
             ]
         ];
 
-        $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', [], $options);
+        $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);
         $body = json_decode($zone->getBody());
         return $body->result;
     }
@@ -87,7 +87,7 @@ class CustomHostnames implements API
             $query['direction'] = $direction;
         }
 
-        $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames', $query, []);
+        $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames', $query);
         $body = json_decode($zone->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -100,7 +100,7 @@ class CustomHostnames implements API
      */
     public function getHostname(string $zoneID, string $hostnameID)
     {
-        $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, [], []);
+        $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID);
         $body = json_decode($zone->getBody());
 
         return $body->result;
@@ -128,10 +128,10 @@ class CustomHostnames implements API
         }
 
         $options = [
-            'ssl' => (object)$query
+            'ssl' => $query
         ];
 
-        $zone = $this->adapter->patch('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, [], $options);
+        $zone = $this->adapter->patch('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, $options);
         $body = json_decode($zone->getBody());
         return $body->result;
     }
@@ -143,7 +143,7 @@ class CustomHostnames implements API
      */
     public function deleteHostname(string $zoneID, string $hostnameID): \stdClass
     {
-        $zone = $this->adapter->delete('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, [], []);
+        $zone = $this->adapter->delete('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID);
         $body = json_decode($zone->getBody());
         return $body;
     }

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -55,7 +55,7 @@ class DNS implements API
             $options['priority'] = $priority;
         }
 
-        $user = $this->adapter->post('zones/' . $zoneID . '/dns_records', [], $options);
+        $user = $this->adapter->post('zones/' . $zoneID . '/dns_records', $options);
 
         $body = json_decode($user->getBody());
 
@@ -103,7 +103,7 @@ class DNS implements API
             $query['direction'] = $direction;
         }
 
-        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -111,20 +111,20 @@ class DNS implements API
 
     public function getRecordDetails(string $zoneID, string $recordID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records/' . $recordID, [], []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/dns_records/' . $recordID);
         $body = json_decode($user->getBody());
         return $body->result;
     }
 
     public function updateRecordDetails(string $zoneID, string $recordID, array $details): \stdClass
     {
-        $response = $this->adapter->put('zones/' . $zoneID . '/dns_records/' . $recordID, [], $details);
+        $response = $this->adapter->put('zones/' . $zoneID . '/dns_records/' . $recordID, $details);
         return json_decode($response->getBody());
     }
 
     public function deleteRecord(string $zoneID, string $recordID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/dns_records/' . $recordID, [], []);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/dns_records/' . $recordID);
 
         $body = json_decode($user->getBody());
 

--- a/src/Endpoints/IPs.php
+++ b/src/Endpoints/IPs.php
@@ -21,7 +21,7 @@ class IPs implements API
 
     public function listIPs(): \stdClass
     {
-        $ips = $this->adapter->get('ips', [], []);
+        $ips = $this->adapter->get('ips');
         $body = json_decode($ips->getBody());
 
         return $body->result;

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -52,7 +52,7 @@ class PageRules implements API
         }
 
 
-        $query = $this->adapter->post('zones/' . $zoneID . '/pagerules', [], $options);
+        $query = $this->adapter->post('zones/' . $zoneID . '/pagerules', $options);
 
         $body = json_decode($query->getBody());
 
@@ -93,7 +93,7 @@ class PageRules implements API
             'match' => $match
         ];
 
-        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules', $query);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -101,7 +101,7 @@ class PageRules implements API
 
     public function getPageRuleDetails(string $zoneID, string $ruleID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules/' . $ruleID, [], []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/pagerules/' . $ruleID);
         $body = json_decode($user->getBody());
         return $body->result;
     }
@@ -132,7 +132,7 @@ class PageRules implements API
         }
 
 
-        $query = $this->adapter->patch('zones/' . $zoneID . '/pagerules', [], $options);
+        $query = $this->adapter->patch('zones/' . $zoneID . '/pagerules', $options);
 
         $body = json_decode($query->getBody());
 
@@ -145,7 +145,7 @@ class PageRules implements API
 
     public function deletePageRule(string $zoneID, string $ruleID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/pagerules/' . $ruleID, [], []);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/pagerules/' . $ruleID);
 
         $body = json_decode($user->getBody());
 

--- a/src/Endpoints/Railgun.php
+++ b/src/Endpoints/Railgun.php
@@ -26,7 +26,7 @@ class Railgun implements API
             'name' => $name,
         ];
 
-        $user = $this->adapter->post('railguns', [], $query);
+        $user = $this->adapter->post('railguns', $query);
         $body = json_decode($user->getBody());
 
         return $body;
@@ -46,7 +46,7 @@ class Railgun implements API
             $query['direction'] = $direction;
         }
 
-        $user = $this->adapter->get('railguns', $query, []);
+        $user = $this->adapter->get('railguns', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -55,7 +55,7 @@ class Railgun implements API
     public function get(
         string $railgunID
     ): \stdClass {
-        $user = $this->adapter->get('railguns/' . $railgunID, [], []);
+        $user = $this->adapter->get('railguns/' . $railgunID);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -64,7 +64,7 @@ class Railgun implements API
     public function getZones(
         string $railgunID
     ): \stdClass {
-        $user = $this->adapter->get('railguns/' . $railgunID . '/zones', [], []);
+        $user = $this->adapter->get('railguns/' . $railgunID . '/zones');
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -78,7 +78,7 @@ class Railgun implements API
             'enabled' => $status
         ];
 
-        $user = $this->adapter->patch('railguns/' . $railgunID, [], $query);
+        $user = $this->adapter->patch('railguns/' . $railgunID, $query);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -87,7 +87,7 @@ class Railgun implements API
     public function delete(
         string $railgunID
     ): bool {
-        $user = $this->adapter->delete('railguns/' . $railgunID, [], []);
+        $user = $this->adapter->delete('railguns/' . $railgunID);
         $body = json_decode($user->getBody());
 
         if (isset($body->result->id)) {

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -30,7 +30,7 @@ class UARules implements API
             'per_page' => $perPage
         ];
 
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -56,7 +56,7 @@ class UARules implements API
             $options['description'] = $description;
         }
 
-        $user = $this->adapter->post('zones/' . $zoneID . '/firewall/ua_rules', [], $options);
+        $user = $this->adapter->post('zones/' . $zoneID . '/firewall/ua_rules', $options);
 
         $body = json_decode($user->getBody());
 
@@ -69,7 +69,7 @@ class UARules implements API
 
     public function getRuleDetails(string $zoneID, string $blockID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules/' . $blockID, [], []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules/' . $blockID);
         $body = json_decode($user->getBody());
         return $body->result;
     }
@@ -91,7 +91,7 @@ class UARules implements API
             $options['description'] = $description;
         }
 
-        $user = $this->adapter->put('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID, [], $options);
+        $user = $this->adapter->put('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID, $options);
 
         $body = json_decode($user->getBody());
 
@@ -104,7 +104,7 @@ class UARules implements API
 
     public function deleteRule(string $zoneID, string $ruleID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID, [], []);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID);
 
         $body = json_decode($user->getBody());
 

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -20,7 +20,7 @@ class User implements API
 
     public function getUserDetails(): \stdClass
     {
-        $user = $this->adapter->get('user', [], []);
+        $user = $this->adapter->get('user');
         $body = json_decode($user->getBody());
         return $body->result;
     }
@@ -37,7 +37,7 @@ class User implements API
 
     public function updateUserDetails(array $details): \stdClass
     {
-        $response = $this->adapter->patch('user', [], $details);
+        $response = $this->adapter->patch('user', $details);
         return json_decode($response->getBody());
     }
 }

--- a/src/Endpoints/WAF.php
+++ b/src/Endpoints/WAF.php
@@ -41,7 +41,7 @@ class WAF implements API
             $query['direction'] = $direction;
         }
 
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -52,7 +52,7 @@ class WAF implements API
         string $zoneID,
         string $packageID
     ): \stdClass {
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID, [], []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -80,7 +80,7 @@ class WAF implements API
         if (!empty($direction)) {
             $query['direction'] = $direction;
         }
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -91,11 +91,7 @@ class WAF implements API
         string $packageID,
         string $ruleID
     ): \stdClass {
-        $user = $this->adapter->get(
-            'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules/' . $ruleID,
-            [],
-            []
-        );
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules/' . $ruleID);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -113,7 +109,6 @@ class WAF implements API
 
         $user = $this->adapter->patch(
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules/' . $ruleID,
-            [],
             $query
         );
         $body = json_decode($user->getBody());
@@ -146,8 +141,7 @@ class WAF implements API
 
         $user = $this->adapter->get(
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups',
-            $query,
-            []
+            $query
         );
         $body = json_decode($user->getBody());
 
@@ -159,11 +153,7 @@ class WAF implements API
         string $packageID,
         string $groupID
     ): \stdClass {
-        $user = $this->adapter->get(
-            'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups/' . $groupID,
-            [],
-            []
-        );
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups/' . $groupID);
         $body = json_decode($user->getBody());
 
         return $body->result;
@@ -181,7 +171,6 @@ class WAF implements API
 
         $user = $this->adapter->patch(
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups/' . $groupID,
-            [],
             $query
         );
         $body = json_decode($user->getBody());

--- a/src/Endpoints/ZoneLockdown.php
+++ b/src/Endpoints/ZoneLockdown.php
@@ -29,7 +29,7 @@ class ZoneLockdown implements API
             'per_page' => $perPage
         ];
 
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns', $query, []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -55,7 +55,7 @@ class ZoneLockdown implements API
             $options['description'] = $description;
         }
 
-        $user = $this->adapter->post('zones/' . $zoneID . '/firewall/lockdowns', [], $options);
+        $user = $this->adapter->post('zones/' . $zoneID . '/firewall/lockdowns', $options);
 
         $body = json_decode($user->getBody());
 
@@ -68,7 +68,7 @@ class ZoneLockdown implements API
 
     public function getLockdownDetails(string $zoneID, string $lockdownID): \stdClass
     {
-        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, [], []);
+        $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID);
         $body = json_decode($user->getBody());
         return $body->result;
     }
@@ -90,7 +90,7 @@ class ZoneLockdown implements API
             $options['description'] = $description;
         }
 
-        $user = $this->adapter->put('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, [], $options);
+        $user = $this->adapter->put('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, $options);
 
         $body = json_decode($user->getBody());
 
@@ -103,7 +103,7 @@ class ZoneLockdown implements API
 
     public function deleteLockdown(string $zoneID, string $lockdownID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, [], []);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID);
 
         $body = json_decode($user->getBody());
 

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -35,17 +35,17 @@ class Zones implements API
         ];
 
         if (!empty($organizationID)) {
-            $options['organization'] = (object)['id' => $organizationID];
+            $options['organization'] = ['id' => $organizationID];
         }
 
-        $user = $this->adapter->post('zones', [], $options);
+        $user = $this->adapter->post('zones', $options);
         $body = json_decode($user->getBody());
         return $body->result;
     }
 
     public function activationCheck(string $zoneID): bool
     {
-        $user = $this->adapter->put('zones/' . $zoneID . '/activation_check', [], []);
+        $user = $this->adapter->put('zones/' . $zoneID . '/activation_check');
         $body = json_decode($user->getBody());
 
         if (isset($body->result->id)) {
@@ -86,7 +86,7 @@ class Zones implements API
             $query['direction'] = $direction;
         }
 
-        $user = $this->adapter->get('zones', $query, []);
+        $user = $this->adapter->get('zones', $query);
         $body = json_decode($user->getBody());
 
         return (object)['result' => $body->result, 'result_info' => $body->result_info];
@@ -114,7 +114,7 @@ class Zones implements API
      */
     public function getAnalyticsDashboard(string $zoneID, string $since = '-10080', string $until = '0', bool $continuous = true): \stdClass
     {
-        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', ['since' => $since, 'until' => $until, 'continuous' => var_export($continuous, true)], []);
+        $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', ['since' => $since, 'until' => $until, 'continuous' => var_export($continuous, true)]);
 
         return json_decode($response->getBody())->result;
     }
@@ -128,7 +128,7 @@ class Zones implements API
      */
     public function changeDevelopmentMode(string $zoneID, bool $enable = false): bool
     {
-        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', [], ['value' => $enable ? 'on' : 'off']);
+        $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', ['value' => $enable ? 'on' : 'off']);
 
         $body = json_decode($response->getBody());
 
@@ -147,7 +147,7 @@ class Zones implements API
      */
     public function cachePurgeEverything(string $zoneID): bool
     {
-        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', [], ['purge_everything' => true]);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', ['purge_everything' => true]);
 
         $body = json_decode($user->getBody());
 
@@ -169,7 +169,7 @@ class Zones implements API
             'tags' => $tags
         ];
 
-        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', [], $options);
+        $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', $options);
 
         $body = json_decode($user->getBody());
 

--- a/tests/Adapter/GuzzleTest.php
+++ b/tests/Adapter/GuzzleTest.php
@@ -41,7 +41,7 @@ class GuzzleTest extends TestCase
 
     public function testPost()
     {
-        $response = $this->client->post('https://httpbin.org/post', [], ['X-Post-Test' => 'Testing a POST request.']);
+        $response = $this->client->post('https://httpbin.org/post', ['X-Post-Test' => 'Testing a POST request.']);
 
         $headers = $response->getHeaders();
         $this->assertEquals('application/json', $headers['Content-Type'][0]);
@@ -52,7 +52,7 @@ class GuzzleTest extends TestCase
 
     public function testPut()
     {
-        $response = $this->client->put('https://httpbin.org/put', [], ['X-Put-Test' => 'Testing a PUT request.']);
+        $response = $this->client->put('https://httpbin.org/put', ['X-Put-Test' => 'Testing a PUT request.']);
 
         $headers = $response->getHeaders();
         $this->assertEquals('application/json', $headers['Content-Type'][0]);
@@ -65,7 +65,6 @@ class GuzzleTest extends TestCase
     {
         $response = $this->client->patch(
             'https://httpbin.org/patch',
-            [],
             ['X-Patch-Test' => 'Testing a PATCH request.']
         );
 
@@ -80,7 +79,6 @@ class GuzzleTest extends TestCase
     {
         $response = $this->client->delete(
             'https://httpbin.org/delete',
-            [],
             ['X-Delete-Test' => 'Testing a DELETE request.']
         );
 

--- a/tests/Configurations/ConfigurationsUARulesTest.php
+++ b/tests/Configurations/ConfigurationsUARulesTest.php
@@ -16,12 +16,12 @@ class ConfigurationsUARulesTest extends TestCase
         $array = $configuration->getArray();
         $this->assertCount(1, $array);
 
-        $this->assertObjectHasAttribute('target', $array[0]);
-        $this->assertEquals('ua', $array[0]->target);
-        $this->assertObjectHasAttribute('value', $array[0]);
+        $this->assertArrayHasKey('target', $array[0]);
+        $this->assertEquals('ua', $array[0]['target']);
+        $this->assertArrayHasKey('value', $array[0]);
         $this->assertEquals(
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4',
-            $array[0]->value
+            $array[0]['value']
         );
     }
 }

--- a/tests/Configurations/ConfigurationsZoneLockdownTest.php
+++ b/tests/Configurations/ConfigurationsZoneLockdownTest.php
@@ -16,19 +16,19 @@ class ConfigurationsZoneLockdownTest extends TestCase
         $array = $configuration->getArray();
         $this->assertCount(1, $array);
 
-        $this->assertObjectHasAttribute('target', $array[0]);
-        $this->assertEquals('ip', $array[0]->target);
-        $this->assertObjectHasAttribute('value', $array[0]);
-        $this->assertEquals('1.2.3.4', $array[0]->value);
+        $this->assertArrayHasKey('target', $array[0]);
+        $this->assertEquals('ip', $array[0]['target']);
+        $this->assertArrayHasKey('value', $array[0]);
+        $this->assertEquals('1.2.3.4', $array[0]['value']);
 
         $configuration->addIPRange('1.2.3.4/24');
 
         $array = $configuration->getArray();
         $this->assertCount(2, $array);
 
-        $this->assertObjectHasAttribute('target', $array[1]);
-        $this->assertEquals('ip_range', $array[1]->target);
-        $this->assertObjectHasAttribute('value', $array[1]);
-        $this->assertEquals('1.2.3.4/24', $array[1]->value);
+        $this->assertArrayHasKey('target', $array[1]);
+        $this->assertEquals('ip_range', $array[1]['target']);
+        $this->assertArrayHasKey('value', $array[1]);
+        $this->assertEquals('1.2.3.4/24', $array[1]['value']);
     }
 }

--- a/tests/Configurations/PageRulesActionTest.php
+++ b/tests/Configurations/PageRulesActionTest.php
@@ -14,8 +14,8 @@ class PageRulesActionTest extends TestCase
         $configuration = $actions->getArray();
 
         $this->assertCount(1, $configuration);
-        $this->assertEquals($identifier, $configuration[0]->id);
-        $this->assertEquals($statusCode, $configuration[0]->value->status_code);
-        $this->assertEquals($forwardingURL, $configuration[0]->value->url);
+        $this->assertEquals($identifier, $configuration[0]['id']);
+        $this->assertEquals($statusCode, $configuration[0]['value']['status_code']);
+        $this->assertEquals($forwardingURL, $configuration[0]['value']['url']);
     }
 }

--- a/tests/Configurations/PageRulesTargetTest.php
+++ b/tests/Configurations/PageRulesTargetTest.php
@@ -16,7 +16,7 @@ class PageRulesTargetTest extends TestCase
         $array = $targets->getArray();
 
         $this->assertCount(1, $array);
-        $this->assertEquals('junade.com/*', $array[0]->constraint->value);
-        $this->assertEquals('matches', $array[0]->constraint->operator);
+        $this->assertEquals('junade.com/*', $array[0]['constraint']['value']);
+        $this->assertEquals('matches', $array[0]['constraint']['operator']);
     }
 }

--- a/tests/Endpoints/AccessRulesTest.php
+++ b/tests/Endpoints/AccessRulesTest.php
@@ -17,8 +17,7 @@ class AccessRulesTest extends TestCase
                     'page' => 1,
                     'per_page' => 50,
                     'match' => 'all'
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\AccessRules($mock);
@@ -45,10 +44,9 @@ class AccessRulesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'challenge',
-                    'configuration' => (object) $config->getArray(),
+                    'configuration' => $config->getArray(),
                     'notes' => 'This rule is on because of an event that occured on date X',
                 ])
             );
@@ -73,7 +71,6 @@ class AccessRulesTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules/92f17202ed8bd63d69a66b86a49a8f6b'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'challenge',
                     'notes' => 'This rule is on because of an event that occured on date X',
@@ -100,7 +97,6 @@ class AccessRulesTest extends TestCase
             ->method('delete')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/access_rules/rules/92f17202ed8bd63d69a66b86a49a8f6b'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'cascade' => 'none'
                 ])

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -21,10 +21,9 @@ class CustomHostnamesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'hostname' => 'app.example.com',
-                    'ssl' => (object)[
+                    'ssl' => [
                         'method' => 'http',
                         'type' => 'dv'
                     ]
@@ -54,8 +53,7 @@ class CustomHostnamesTest extends TestCase
                     'order' => 'ssl',
                     'direction' => 'desc',
                     'ssl' => 0
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\CustomHostnames($mock);
@@ -78,9 +76,7 @@ class CustomHostnamesTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9')
             );
 
         $zones = new \Cloudflare\API\Endpoints\CustomHostnames($mock);
@@ -101,9 +97,8 @@ class CustomHostnamesTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9'),
-                $this->equalTo([]),
                 $this->equalTo([
-                    'ssl' => (object)[
+                    'ssl' => [
                         'method' => 'http',
                         'type' =>  'dv'
                     ]
@@ -127,9 +122,7 @@ class CustomHostnamesTest extends TestCase
         $mock->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9')
             );
 
         $zones = new \Cloudflare\API\Endpoints\CustomHostnames($mock);

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -19,7 +19,6 @@ class DNSTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'type' => 'A',
                     'name' => 'example.com',
@@ -44,16 +43,16 @@ class DNSTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records'),
-              $this->equalTo([
-                'page' => 1,
-                'per_page' => 20,
-                'match' => 'all',
-                'type' => 'A',
-                'name' => 'example.com',
-                'content' => '127.0.0.1',
-                'order' => 'type',
-                'direction' => 'desc']),
-              $this->equalTo([])
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 20,
+                    'match' => 'all',
+                    'type' => 'A',
+                    'name' => 'example.com',
+                    'content' => '127.0.0.1',
+                    'order' => 'type',
+                    'direction' => 'desc',
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\DNS($mock);
@@ -76,8 +75,7 @@ class DNSTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records/372e67954025e0ba6aaa6d586b9e0b59')
             );
 
         $dns = new \Cloudflare\API\Endpoints\DNS($mock);
@@ -105,7 +103,6 @@ class DNSTest extends TestCase
             ->method('put')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([]),
                 $this->equalTo($details)
             );
 

--- a/tests/Endpoints/IPsTest.php
+++ b/tests/Endpoints/IPsTest.php
@@ -18,8 +18,7 @@ class IPsTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('ips'),
-                $this->equalTo([])
+                $this->equalTo('ips')
             );
 
         $ips = new \Cloudflare\API\Endpoints\IPs($mock);

--- a/tests/Endpoints/PageRulesTest.php
+++ b/tests/Endpoints/PageRulesTest.php
@@ -23,7 +23,6 @@ class PageRulesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'targets' => $target->getArray(),
                     'actions' => $action->getArray(),
@@ -54,8 +53,7 @@ class PageRulesTest extends TestCase
                 'order' => 'status',
                 'direction' => 'desc',
                 'match' => 'all'
-              ]),
-              $this->equalTo([])
+              ])
             );
 
         $pageRules = new \Cloudflare\API\Endpoints\PageRules($mock);
@@ -72,8 +70,7 @@ class PageRulesTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules/9a7806061c88ada191ed06f989cc3dac'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules/9a7806061c88ada191ed06f989cc3dac')
             );
 
         $pageRules = new \Cloudflare\API\Endpoints\PageRules($mock);
@@ -95,7 +92,6 @@ class PageRulesTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'targets' => $target->getArray(),
                     'actions' => $action->getArray(),
@@ -120,9 +116,7 @@ class PageRulesTest extends TestCase
         $mock->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules/9a7806061c88ada191ed06f989cc3dac'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/pagerules/9a7806061c88ada191ed06f989cc3dac')
             );
 
         $pageRules = new \Cloudflare\API\Endpoints\PageRules($mock);

--- a/tests/Endpoints/RailgunTest.php
+++ b/tests/Endpoints/RailgunTest.php
@@ -23,7 +23,6 @@ class RailgunTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('railguns'),
-                $this->equalTo([]),
                 $this->equalTo(['name' => $details['name']])
             );
 
@@ -52,8 +51,7 @@ class RailgunTest extends TestCase
                     'page' => 1,
                     'per_page' => 20,
                     'direction' => 'desc'
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
@@ -73,8 +71,7 @@ class RailgunTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('railguns/e928d310693a83094309acf9ead50448'),
-                $this->equalTo([])
+                $this->equalTo('railguns/e928d310693a83094309acf9ead50448')
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
@@ -93,9 +90,7 @@ class RailgunTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('railguns/e928d310693a83094309acf9ead50448/zones'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('railguns/e928d310693a83094309acf9ead50448/zones')
             );
 
         $railgun = new \Cloudflare\API\Endpoints\Railgun($mock);
@@ -120,7 +115,6 @@ class RailgunTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('railguns/e928d310693a83094309acf9ead50448'),
-                $this->equalTo([]),
                 $this->equalTo($details)
             );
 
@@ -140,9 +134,7 @@ class RailgunTest extends TestCase
         $mock->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('railguns/e928d310693a83094309acf9ead50448'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('railguns/e928d310693a83094309acf9ead50448')
             );
 
         $waf = new \Cloudflare\API\Endpoints\Railgun($mock);

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -22,8 +22,7 @@ class UARulesTest extends TestCase
               $this->equalTo([
                 'page' => 1,
                 'per_page' => 20
-              ]),
-              $this->equalTo([])
+              ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\UARules($mock);
@@ -50,7 +49,6 @@ class UARulesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'js_challenge',
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
@@ -79,8 +77,7 @@ class UARulesTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules/372e67954025e0ba6aaa6d586b9e0b59')
             );
 
         $lockdown = new \Cloudflare\API\Endpoints\UARules($mock);
@@ -103,7 +100,6 @@ class UARulesTest extends TestCase
             ->method('put')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'mode' => 'js_challenge',
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
@@ -132,9 +128,7 @@ class UARulesTest extends TestCase
         $mock->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/ua_rules/372e67954025e0ba6aaa6d586b9e0b59')
             );
 
         $rules = new \Cloudflare\API\Endpoints\UARules($mock);

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -56,7 +56,7 @@ class UserTest extends TestCase
 
         $mock->expects($this->once())
             ->method('patch')
-            ->with($this->equalTo('user'), $this->equalTo([]), $this->equalTo(['email' => 'user2@example.com']));
+            ->with($this->equalTo('user'), $this->equalTo(['email' => 'user2@example.com']));
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
         $user->updateUserDetails(['email' => 'user2@example.com']);

--- a/tests/Endpoints/WAFTest.php
+++ b/tests/Endpoints/WAFTest.php
@@ -25,8 +25,7 @@ class WAFTest extends TestCase
                     'match' => 'all',
                     'order' => 'status',
                     'direction' => 'desc'
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -49,8 +48,7 @@ class WAFTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b')
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -76,8 +74,7 @@ class WAFTest extends TestCase
                     'match' => 'all',
                     'order' => 'status',
                     'direction' => 'desc'
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -100,8 +97,7 @@ class WAFTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/rules/f939de3be84e66e757adcdcb87908023'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/rules/f939de3be84e66e757adcdcb87908023')
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -125,7 +121,6 @@ class WAFTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/rules/f939de3be84e66e757adcdcb87908023'),
-                $this->equalTo([]),
                 $this->equalTo($details)
             );
 
@@ -156,8 +151,7 @@ class WAFTest extends TestCase
                     'match' => 'all',
                     'order' => 'status',
                     'direction' => 'desc'
-                ]),
-                $this->equalTo([])
+                ])
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -180,8 +174,7 @@ class WAFTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/groups/de677e5818985db1285d0e80225f06e5'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/groups/de677e5818985db1285d0e80225f06e5')
             );
 
         $waf = new \Cloudflare\API\Endpoints\WAF($mock);
@@ -205,7 +198,6 @@ class WAFTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/groups/de677e5818985db1285d0e80225f06e5'),
-                $this->equalTo([]),
                 $this->equalTo($details)
             );
 

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -19,11 +19,10 @@ class ZoneLockdownTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns'),
-              $this->equalTo([
-                'page' => 1,
-                'per_page' => 20,
-              ]),
-              $this->equalTo([])
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 20,
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
@@ -50,7 +49,6 @@ class ZoneLockdownTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'urls' => ['api.mysite.com/some/endpoint*'],
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
@@ -79,8 +77,7 @@ class ZoneLockdownTest extends TestCase
         $mock->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59')
             );
 
         $lockdown = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
@@ -103,7 +100,6 @@ class ZoneLockdownTest extends TestCase
             ->method('put')
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'urls' => ['api.mysite.com/some/endpoint*'],
                     'id' => '372e67954025e0ba6aaa6d586b9e0b59',
@@ -135,9 +131,7 @@ class ZoneLockdownTest extends TestCase
         $mock->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/lockdowns/372e67954025e0ba6aaa6d586b9e0b59')
             );
 
         $zoneLockdown = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -19,7 +19,6 @@ class ZonesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones'),
-                $this->equalTo([]),
                 $this->equalTo(['name' => 'example.com', 'jump_start' => false])
             );
 
@@ -38,11 +37,10 @@ class ZonesTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones'),
-                $this->equalTo([]),
                 $this->equalTo([
                     'name' => 'example.com',
                     'jump_start' => true,
-                    'organization' => (object)['id' => '01a7362d577a6c3019a474fd6f485823']
+                    'organization' => ['id' => '01a7362d577a6c3019a474fd6f485823']
                 ])
             );
 
@@ -60,9 +58,7 @@ class ZonesTest extends TestCase
         $mock->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/activation_check'),
-                $this->equalTo([]),
-                $this->equalTo([])
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/activation_check')
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
@@ -82,16 +78,15 @@ class ZonesTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones'),
-              $this->equalTo([
-                'page' => 1,
-                'per_page' => 20,
-                'match' => 'all',
-                'name' => 'example.com',
-                'status' => 'active',
-                'order' => 'status',
-                'direction' => 'desc'
-              ]),
-                $this->equalTo([])
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 20,
+                    'match' => 'all',
+                    'name' => 'example.com',
+                    'status' => 'active',
+                    'order' => 'status',
+                    'direction' => 'desc',
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
@@ -115,13 +110,12 @@ class ZonesTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones'),
-              $this->equalTo([
-                'page' => 1,
-                'per_page' => 20,
-                'match' => 'all',
-                'name' => 'example.com',
-                ]),
-              $this->equalTo([])
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 20,
+                    'match' => 'all',
+                    'name' => 'example.com',
+                ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
@@ -141,8 +135,7 @@ class ZonesTest extends TestCase
             ->method('get')
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/analytics/dashboard'),
-                $this->equalTo(['since' => '-10080', 'until' => '0', 'continuous' => var_export(true, true)]),
-                $this->equalTo([])
+                $this->equalTo(['since' => '-10080', 'until' => '0', 'continuous' => var_export(true, true)])
             );
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
@@ -163,7 +156,6 @@ class ZonesTest extends TestCase
             ->method('patch')
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/settings/development_mode'),
-                $this->equalTo([]),
                 $this->equalTo(['value' => 'on'])
             );
 
@@ -184,7 +176,6 @@ class ZonesTest extends TestCase
             ->method('delete')
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
-                $this->equalTo([]),
                 $this->equalTo(['purge_everything' => true])
             );
 


### PR DESCRIPTION
This PR looks a lot larger/scarier than it actually is. I've broken it down below!

Adapter::get, post, put, patch and delete all had non-optional parameters for $headers and $query or $body. These have been made optional. I also re-ordered the parameters as $headers was never used while $query/$body were heavily used. I also condensed and removed some duplicate calls so that every call to Adapter::get/post sends that call to Adapter::request. It could use a magic method to do this but it might make it more difficult to test.

`Adapter::get/post/put/patch/delete` all had non-optional parameters for `$headers` and `$query` or `$body`. This has been standardized (reordered some) to `array $data = []` and `array $headers = []` as `$headers` is rarely ever used (if at all). Both parameters are optional now. This allows us to remove tons of unnecessary empty array parameters all over method calls and tests!

Adapter::get/post/put/patch/delete all had nearly-duplicate code. Each of those methods have been updated to call a shared `Adapter::request()` which accepts a method parameter first and then the standard `string $uri, array $data = [], array $headers = []`.

I've also removed the unneeded object casting for arrays that are sent to the API. In the case of things like `organization => (object) ['id' => $orgId]` it just adds unnecessary fluff when Guzzle `json_encodes` it, it all turns out to be the same json whether it's an object or array. Removing it allows us to remove tons of `(object)` casts all over the project.

All in all, this PR has a net of 100 deletions (173 additions / 277 deletions) which cleans things up a lot. Test suite is all passing and I've (actually) tested the majority of each endpoint through the API. There's no breaking changes unless someone has extended the class or calls methods on the adapter/client directly.

Further down the road, I'd like to have the adapter's methods return an object decoded from the json. Instead of having `$body = json_decode($data->getBody());` in every API class method, it'd be handled within the adapter, removing tons of duplicate code. The error handling is already checked in the adapter, so it seems this would be a good place to handle it too.