### PR TITLE
Add support for host-based cache purge

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -158,15 +158,16 @@ class Zones implements API
         return false;
     }
 
-    public function cachePurge(string $zoneID, array $files = null, array $tags = null): bool
+    public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null): bool
     {
-        if ($files === null && $tags === null) {
-            throw new EndpointException('No files or tags to purge.');
+        if ($files === null && $tags === null && $hosts === null) {
+            throw new EndpointException('No files, tags or hosts to purge.');
         }
 
         $options = [
             'files' => $files,
-            'tags' => $tags
+            'tags' => $tags,
+            'hosts' => $hosts
         ];
 
         $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', $options);

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -144,7 +144,7 @@ class ZonesTest extends TestCase
         $this->assertObjectHasAttribute('since', $analytics->totals);
         $this->assertObjectHasAttribute('since', $analytics->timeseries[0]);
     }
-    
+
     public function testChangeDevelopmentMode()
     {
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/changeDevelopmentMode.json');
@@ -181,6 +181,32 @@ class ZonesTest extends TestCase
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
         $result = $zones->cachePurgeEverything('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
+
+        $this->assertTrue($result);
+    }
+
+    public function testCachePurgeHost()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/cachePurgeHost.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('delete')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
+                $this->equalTo(
+                    [
+                        'files' => [],
+                        'tags' => [],
+                        'hosts' => ['dash.cloudflare.com']
+                    ]
+                )
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\Zones($mock);
+        $result = $zones->cachePurge('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', [], [], ['dash.cloudflare.com']);
 
         $this->assertTrue($result);
     }

--- a/tests/Fixtures/Endpoints/cachePurgeHost.json
+++ b/tests/Fixtures/Endpoints/cachePurgeHost.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353"
+  }
+}


### PR DESCRIPTION
Currently `\Cloudflare\API\Endpoints\Zones::cachePurge` supports only url- and tag- based purges. This PR adds support for missing purge by hostname feature.