### PR TITLE
Fixes issue with creating a MX record

### DIFF
--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -52,7 +52,7 @@ class DNS implements API
         }
 
         if (!empty($priority)) {
-            $options['priority'] = $priority;
+            $options['priority'] = (int)$priority;
         }
 
         $user = $this->adapter->post('zones/' . $zoneID . '/dns_records', $options);


### PR DESCRIPTION
Fixes #60
php api expects a string and cloudflare api expects a int
this keeps everybody happy without changing API's