### PR TITLE
Added a `body` property to the endpoint classes with an accessor

### DIFF
--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -4,9 +4,12 @@ namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
 use Cloudflare\API\Configurations\Configurations;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class AccessRules implements API
 {
+    use BodyAccessorTrait;
+    
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -78,9 +81,9 @@ class AccessRules implements API
         }
 
         $data = $this->adapter->get('zones/' . $zoneID . '/firewall/access_rules/rules', $query);
-        $body = json_decode($data->getBody());
+        $this->body = json_decode($data->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function createRule(
@@ -100,9 +103,9 @@ class AccessRules implements API
 
         $query = $this->adapter->post('zones/' . $zoneID . '/firewall/access_rules/rules', $options);
 
-        $body = json_decode($query->getBody());
+        $this->body = json_decode($query->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -125,9 +128,9 @@ class AccessRules implements API
 
         $query = $this->adapter->patch('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, $options);
 
-        $body = json_decode($query->getBody());
+        $this->body = json_decode($query->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -142,9 +145,9 @@ class AccessRules implements API
 
         $data = $this->adapter->delete('zones/' . $zoneID . '/firewall/access_rules/rules/' . $ruleID, $options);
 
-        $body = json_decode($data->getBody());
+        $this->body = json_decode($data->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class CustomHostnames implements API
 {
+    use BodyAccessorTrait;
+    
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -40,8 +43,8 @@ class CustomHostnames implements API
         ];
 
         $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);
-        $body = json_decode($zone->getBody());
-        return $body->result;
+        $this->body = json_decode($zone->getBody());
+        return $this->body->result;
     }
 
     /**
@@ -88,9 +91,9 @@ class CustomHostnames implements API
         }
 
         $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames', $query);
-        $body = json_decode($zone->getBody());
+        $this->body = json_decode($zone->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     /**
@@ -101,9 +104,9 @@ class CustomHostnames implements API
     public function getHostname(string $zoneID, string $hostnameID)
     {
         $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID);
-        $body = json_decode($zone->getBody());
+        $this->body = json_decode($zone->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     /**
@@ -132,8 +135,8 @@ class CustomHostnames implements API
         ];
 
         $zone = $this->adapter->patch('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, $options);
-        $body = json_decode($zone->getBody());
-        return $body->result;
+        $this->body = json_decode($zone->getBody());
+        return $this->body->result;
     }
 
     /**
@@ -144,7 +147,7 @@ class CustomHostnames implements API
     public function deleteHostname(string $zoneID, string $hostnameID): \stdClass
     {
         $zone = $this->adapter->delete('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID);
-        $body = json_decode($zone->getBody());
-        return $body;
+        $this->body = json_decode($zone->getBody());
+        return $this->body;
     }
 }

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class DNS implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -57,9 +60,9 @@ class DNS implements API
 
         $user = $this->adapter->post('zones/' . $zoneID . '/dns_records', $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -104,31 +107,32 @@ class DNS implements API
         }
 
         $user = $this->adapter->get('zones/' . $zoneID . '/dns_records', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function getRecordDetails(string $zoneID, string $recordID): \stdClass
     {
         $user = $this->adapter->get('zones/' . $zoneID . '/dns_records/' . $recordID);
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function updateRecordDetails(string $zoneID, string $recordID, array $details): \stdClass
     {
         $response = $this->adapter->put('zones/' . $zoneID . '/dns_records/' . $recordID, $details);
-        return json_decode($response->getBody());
+        $this->body = json_decode($response->getBody());
+        return $this->body;
     }
 
     public function deleteRecord(string $zoneID, string $recordID): bool
     {
         $user = $this->adapter->delete('zones/' . $zoneID . '/dns_records/' . $recordID);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/IPs.php
+++ b/src/Endpoints/IPs.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class IPs implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -22,8 +25,8 @@ class IPs implements API
     public function listIPs(): \stdClass
     {
         $ips = $this->adapter->get('ips');
-        $body = json_decode($ips->getBody());
+        $this->body = json_decode($ips->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 }

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -11,9 +11,12 @@ namespace Cloudflare\API\Endpoints;
 use Cloudflare\API\Adapter\Adapter;
 use Cloudflare\API\Configurations\PageRulesActions;
 use Cloudflare\API\Configurations\PageRulesTargets;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class PageRules implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -54,9 +57,9 @@ class PageRules implements API
 
         $query = $this->adapter->post('zones/' . $zoneID . '/pagerules', $options);
 
-        $body = json_decode($query->getBody());
+        $this->body = json_decode($query->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -94,16 +97,16 @@ class PageRules implements API
         ];
 
         $user = $this->adapter->get('zones/' . $zoneID . '/pagerules', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function getPageRuleDetails(string $zoneID, string $ruleID): \stdClass
     {
         $user = $this->adapter->get('zones/' . $zoneID . '/pagerules/' . $ruleID);
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function updatePageRule(
@@ -134,9 +137,9 @@ class PageRules implements API
 
         $query = $this->adapter->patch('zones/' . $zoneID . '/pagerules', $options);
 
-        $body = json_decode($query->getBody());
+        $this->body = json_decode($query->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -147,9 +150,9 @@ class PageRules implements API
     {
         $user = $this->adapter->delete('zones/' . $zoneID . '/pagerules/' . $ruleID);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/Railgun.php
+++ b/src/Endpoints/Railgun.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class Railgun implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -27,9 +30,9 @@ class Railgun implements API
         ];
 
         $user = $this->adapter->post('railguns', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body;
+        return $this->body;
     }
 
     public function list(
@@ -47,27 +50,27 @@ class Railgun implements API
         }
 
         $user = $this->adapter->get('railguns', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function get(
         string $railgunID
     ): \stdClass {
         $user = $this->adapter->get('railguns/' . $railgunID);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function getZones(
         string $railgunID
     ): \stdClass {
         $user = $this->adapter->get('railguns/' . $railgunID . '/zones');
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function update(
@@ -79,18 +82,18 @@ class Railgun implements API
         ];
 
         $user = $this->adapter->patch('railguns/' . $railgunID, $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function delete(
         string $railgunID
     ): bool {
         $user = $this->adapter->delete('railguns/' . $railgunID);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -10,9 +10,12 @@ namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Configurations\Configurations;
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class UARules implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -31,9 +34,9 @@ class UARules implements API
         ];
 
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function createRule(
@@ -58,9 +61,9 @@ class UARules implements API
 
         $user = $this->adapter->post('zones/' . $zoneID . '/firewall/ua_rules', $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -70,8 +73,8 @@ class UARules implements API
     public function getRuleDetails(string $zoneID, string $blockID): \stdClass
     {
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/ua_rules/' . $blockID);
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function updateRule(
@@ -93,9 +96,9 @@ class UARules implements API
 
         $user = $this->adapter->put('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID, $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -106,9 +109,9 @@ class UARules implements API
     {
         $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/ua_rules/' . $ruleID);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -8,9 +8,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class User implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -21,8 +24,8 @@ class User implements API
     public function getUserDetails(): \stdClass
     {
         $user = $this->adapter->get('user');
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function getUserID(): string
@@ -38,6 +41,7 @@ class User implements API
     public function updateUserDetails(array $details): \stdClass
     {
         $response = $this->adapter->patch('user', $details);
-        return json_decode($response->getBody());
+        $this->body = json_decode($response->getBody());
+        return $this->body;
     }
 }

--- a/src/Endpoints/WAF.php
+++ b/src/Endpoints/WAF.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class WAF implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -42,9 +45,9 @@ class WAF implements API
         }
 
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
 
@@ -53,9 +56,9 @@ class WAF implements API
         string $packageID
     ): \stdClass {
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function getRules(
@@ -81,9 +84,9 @@ class WAF implements API
             $query['direction'] = $direction;
         }
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function getRuleInfo(
@@ -92,9 +95,9 @@ class WAF implements API
         string $ruleID
     ): \stdClass {
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules/' . $ruleID);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function updateRule(
@@ -111,9 +114,9 @@ class WAF implements API
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/rules/' . $ruleID,
             $query
         );
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function getGroups(
@@ -143,9 +146,9 @@ class WAF implements API
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups',
             $query
         );
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function getGroupInfo(
@@ -154,9 +157,9 @@ class WAF implements API
         string $groupID
     ): \stdClass {
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups/' . $groupID);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 
     public function updateGroup(
@@ -173,8 +176,8 @@ class WAF implements API
             'zones/' . $zoneID . '/firewall/waf/packages/' . $packageID . '/groups/' . $groupID,
             $query
         );
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return $body->result;
+        return $this->body->result;
     }
 }

--- a/src/Endpoints/ZoneLockdown.php
+++ b/src/Endpoints/ZoneLockdown.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class ZoneLockdown implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -30,9 +33,9 @@ class ZoneLockdown implements API
         ];
 
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function createLockdown(
@@ -57,9 +60,9 @@ class ZoneLockdown implements API
 
         $user = $this->adapter->post('zones/' . $zoneID . '/firewall/lockdowns', $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -69,8 +72,8 @@ class ZoneLockdown implements API
     public function getLockdownDetails(string $zoneID, string $lockdownID): \stdClass
     {
         $user = $this->adapter->get('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID);
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function updateLockdown(
@@ -92,9 +95,9 @@ class ZoneLockdown implements API
 
         $user = $this->adapter->put('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID, $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -105,9 +108,9 @@ class ZoneLockdown implements API
     {
         $user = $this->adapter->delete('zones/' . $zoneID . '/firewall/lockdowns/' . $lockdownID);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -42,16 +42,16 @@ class Zones implements API
         }
 
         $user = $this->adapter->post('zones', $options);
-        $body = json_decode($user->getBody());
-        return $body->result;
+        $this->body = json_decode($user->getBody());
+        return $this->body->result;
     }
 
     public function activationCheck(string $zoneID): bool
     {
         $user = $this->adapter->put('zones/' . $zoneID . '/activation_check');
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 
@@ -90,9 +90,9 @@ class Zones implements API
         }
 
         $user = $this->adapter->get('zones', $query);
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        return (object)['result' => $body->result, 'result_info' => $body->result_info];
+        return (object)['result' => $this->body->result, 'result_info' => $this->body->result_info];
     }
 
     public function getZoneID(string $name = ''): string
@@ -119,7 +119,9 @@ class Zones implements API
     {
         $response = $this->adapter->get('zones/' . $zoneID . '/analytics/dashboard', ['since' => $since, 'until' => $until, 'continuous' => var_export($continuous, true)]);
 
-        return json_decode($response->getBody())->result;
+        $this->body = $response->getBody();
+
+        return json_decode($this->body)->result;
     }
 
     /**
@@ -133,9 +135,9 @@ class Zones implements API
     {
         $response = $this->adapter->patch('zones/' . $zoneID . '/settings/development_mode', ['value' => $enable ? 'on' : 'off']);
 
-        $body = json_decode($response->getBody());
+        $this->body = json_decode($response->getBody());
 
-        if ($body->success) {
+        if ($this->body->success) {
             return true;
         }
 
@@ -152,9 +154,9 @@ class Zones implements API
     {
         $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', ['purge_everything' => true]);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -9,9 +9,12 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Traits\BodyAccessorTrait;
 
 class Zones implements API
 {
+    use BodyAccessorTrait;
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -172,16 +175,16 @@ class Zones implements API
         if (!is_null($tags)) {
             $options['tags'] = $tags;
         }
-      
+
         if (!is_null($hosts)) {
             $options['hosts'] = $hosts;
         }
 
         $user = $this->adapter->delete('zones/' . $zoneID . '/purge_cache', $options);
 
-        $body = json_decode($user->getBody());
+        $this->body = json_decode($user->getBody());
 
-        if (isset($body->result->id)) {
+        if (isset($this->body->result->id)) {
             return true;
         }
 

--- a/src/Traits/BodyAccessorTrait.php
+++ b/src/Traits/BodyAccessorTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Cloudflare\API\Traits;
+
+trait BodyAccessorTrait {
+    private $body;
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+}

--- a/src/Traits/BodyAccessorTrait.php
+++ b/src/Traits/BodyAccessorTrait.php
@@ -2,7 +2,8 @@
 
 namespace Cloudflare\API\Traits;
 
-trait BodyAccessorTrait {
+trait BodyAccessorTrait
+{
     private $body;
 
     public function getBody()

--- a/tests/Endpoints/AccessRulesTest.php
+++ b/tests/Endpoints/AccessRulesTest.php
@@ -28,6 +28,7 @@ class AccessRulesTest extends TestCase
 
         $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $zones->getBody()->result[0]->id);
     }
 
     public function testCreateRule()
@@ -58,6 +59,7 @@ class AccessRulesTest extends TestCase
             $config,
             'This rule is on because of an event that occured on date X'
         );
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $rules->getBody()->result->id);
     }
 
     public function testUpdateRule()
@@ -84,6 +86,7 @@ class AccessRulesTest extends TestCase
             'challenge',
             'This rule is on because of an event that occured on date X'
         );
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $rules->getBody()->result->id);
     }
 
     public function testDeleteRule()
@@ -104,5 +107,6 @@ class AccessRulesTest extends TestCase
 
         $rules = new \Cloudflare\API\Endpoints\AccessRules($mock);
         $rules->deleteRule('023e105f4ecef8ad9ca31a8372d0c353', '92f17202ed8bd63d69a66b86a49a8f6b');
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $rules->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -32,6 +32,7 @@ class CustomHostnamesTest extends TestCase
 
         $hostname = new CustomHostnames($mock);
         $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv');
+        $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 
     public function testListHostnames()
@@ -64,6 +65,7 @@ class CustomHostnamesTest extends TestCase
 
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->result[0]->id);
     }
 
     public function testGetHostname()
@@ -84,6 +86,7 @@ class CustomHostnamesTest extends TestCase
 
         $this->assertObjectHasAttribute('id', $result);
         $this->assertObjectHasAttribute('hostname', $result);
+        $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->result->id);
     }
 
     public function testUpdateHostname()
@@ -110,6 +113,7 @@ class CustomHostnamesTest extends TestCase
 
         $this->assertObjectHasAttribute('id', $result);
         $this->assertObjectHasAttribute('hostname', $result);
+        $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->result->id);
     }
 
     public function testDeleteHostname()
@@ -129,5 +133,6 @@ class CustomHostnamesTest extends TestCase
         $result = $zones->deleteHostname('023e105f4ecef8ad9ca31a8372d0c353', '0d89c70d-ad9f-4843-b99f-6cc0252067e9');
 
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $result->id);
+        $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->id);
     }
 }

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -63,6 +63,7 @@ class DNSTest extends TestCase
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zones->getBody()->result[0]->id);
     }
 
     public function testGetDNSRecordDetails()
@@ -82,6 +83,7 @@ class DNSTest extends TestCase
         $result = $dns->getRecordDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $dns->getBody()->result->id);
     }
 
     public function testUpdateDNSRecord()
@@ -110,6 +112,7 @@ class DNSTest extends TestCase
         $result = $dns->updateRecordDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59', $details);
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $dns->getBody()->result->id);
 
         foreach ($details as $property => $value) {
             $this->assertEquals($result->result->{ $property }, $value);

--- a/tests/Endpoints/IPsTest.php
+++ b/tests/Endpoints/IPsTest.php
@@ -21,9 +21,11 @@ class IPsTest extends TestCase
                 $this->equalTo('ips')
             );
 
-        $ips = new \Cloudflare\API\Endpoints\IPs($mock);
-        $ips = $ips->listIPs();
+        $ipsMock = new \Cloudflare\API\Endpoints\IPs($mock);
+        $ips = $ipsMock->listIPs();
         $this->assertObjectHasAttribute('ipv4_cidrs', $ips);
         $this->assertObjectHasAttribute('ipv6_cidrs', $ips);
+        $this->assertObjectHasAttribute('ipv4_cidrs', $ipsMock->getBody()->result);
+        $this->assertObjectHasAttribute('ipv6_cidrs', $ipsMock->getBody()->result);
     }
 }

--- a/tests/Endpoints/PageRulesTest.php
+++ b/tests/Endpoints/PageRulesTest.php
@@ -35,6 +35,7 @@ class PageRulesTest extends TestCase
         $result = $pageRules->createPageRule('023e105f4ecef8ad9ca31a8372d0c353', $target, $action, true, 1);
 
         $this->assertTrue($result);
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $pageRules->getBody()->result->id);
     }
 
     public function testListPageRules()
@@ -58,6 +59,7 @@ class PageRulesTest extends TestCase
 
         $pageRules = new \Cloudflare\API\Endpoints\PageRules($mock);
         $pageRules->listPageRules('023e105f4ecef8ad9ca31a8372d0c353', 'active', 'status', 'desc', 'all');
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $pageRules->getBody()->result[0]->id);
     }
 
     public function testGetPageRuleDetails()
@@ -75,6 +77,7 @@ class PageRulesTest extends TestCase
 
         $pageRules = new \Cloudflare\API\Endpoints\PageRules($mock);
         $pageRules->getPageRuleDetails('023e105f4ecef8ad9ca31a8372d0c353', '9a7806061c88ada191ed06f989cc3dac');
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $pageRules->getBody()->result->id);
     }
 
     public function testUpdatePageRule()
@@ -104,6 +107,7 @@ class PageRulesTest extends TestCase
         $result = $pageRules->updatePageRule('023e105f4ecef8ad9ca31a8372d0c353', $target, $action, true, 1);
 
         $this->assertTrue($result);
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $pageRules->getBody()->result->id);
     }
 
     public function testDeletePageRule()
@@ -123,5 +127,6 @@ class PageRulesTest extends TestCase
         $result = $pageRules->deletePageRule('023e105f4ecef8ad9ca31a8372d0c353', '9a7806061c88ada191ed06f989cc3dac');
 
         $this->assertTrue($result);
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $pageRules->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/RailgunTest.php
+++ b/tests/Endpoints/RailgunTest.php
@@ -34,6 +34,7 @@ class RailgunTest extends TestCase
         foreach ($details as $property => $value) {
             $this->assertEquals($result->result->{ $property }, $value);
         }
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $railgun->getBody()->result->id);
     }
 
     public function testlist()
@@ -59,6 +60,7 @@ class RailgunTest extends TestCase
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $railgun->getBody()->result[0]->id);
     }
 
     public function testget()
@@ -78,6 +80,7 @@ class RailgunTest extends TestCase
         $result = $railgun->get('e928d310693a83094309acf9ead50448');
 
         $this->assertEquals('e928d310693a83094309acf9ead50448', $result->id);
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $railgun->getBody()->result->id);
     }
 
     public function testgetZones()
@@ -98,6 +101,7 @@ class RailgunTest extends TestCase
 
         $this->assertObjectHasAttribute('result', $result);
         $this->assertObjectHasAttribute('result_info', $result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $railgun->getBody()->result[0]->id);
     }
 
     public function testupdate()
@@ -122,6 +126,7 @@ class RailgunTest extends TestCase
         $result = $waf->update('e928d310693a83094309acf9ead50448', true);
 
         $this->assertEquals('e928d310693a83094309acf9ead50448', $result->id);
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $waf->getBody()->result->id);
     }
 
     public function testdelete()
@@ -139,5 +144,6 @@ class RailgunTest extends TestCase
 
         $waf = new \Cloudflare\API\Endpoints\Railgun($mock);
         $waf->delete('e928d310693a83094309acf9ead50448');
+        $this->assertEquals('e928d310693a83094309acf9ead50448', $waf->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -33,6 +33,7 @@ class UARulesTest extends TestCase
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zones->getBody()->result[0]->id);
     }
 
     public function testCreateRule()
@@ -65,6 +66,7 @@ class UARulesTest extends TestCase
             '372e67954025e0ba6aaa6d586b9e0b59',
             'Prevent access from abusive clients identified by this UserAgent to mitigate DDoS attack'
         );
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $rules->getBody()->result->id);
     }
 
     public function getRuleDetails()
@@ -84,6 +86,7 @@ class UARulesTest extends TestCase
         $result = $lockdown->getRuleDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $rules->getBody()->result->id);
     }
 
     public function testUpdateRule()
@@ -116,6 +119,7 @@ class UARulesTest extends TestCase
             $config,
             'Restrict access to these endpoints to requests from a known IP address'
         );
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $rules->getBody()->result->id);
     }
 
     public function testDeleteRule()
@@ -133,5 +137,6 @@ class UARulesTest extends TestCase
 
         $rules = new \Cloudflare\API\Endpoints\UARules($mock);
         $rules->deleteRule('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $rules->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/UARulesTest.php
+++ b/tests/Endpoints/UARulesTest.php
@@ -86,7 +86,7 @@ class UARulesTest extends TestCase
         $result = $lockdown->getRuleDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
-        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $rules->getBody()->result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $lockdown->getBody()->result->id);
     }
 
     public function testUpdateRule()

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -21,6 +21,7 @@ class UserTest extends TestCase
         $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $details->id);
         $this->assertObjectHasAttribute('email', $details);
         $this->assertEquals('user@example.com', $details->email);
+        $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $user->getBody()->result->id);
     }
 
     public function testGetUserID()
@@ -32,6 +33,7 @@ class UserTest extends TestCase
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
         $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $user->getUserID());
+        $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $user->getBody()->result->id);
     }
 
     public function testGetUserEmail()
@@ -45,6 +47,7 @@ class UserTest extends TestCase
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
         $this->assertEquals('user@example.com', $user->getUserEmail());
+        $this->assertEquals('user@example.com', $user->getBody()->result->email);
     }
 
     public function testUpdateUserDetails()
@@ -60,5 +63,6 @@ class UserTest extends TestCase
 
         $user = new \Cloudflare\API\Endpoints\User($mock);
         $user->updateUserDetails(['email' => 'user2@example.com']);
+        $this->assertEquals('7c5dae5552338874e5053f2534d2767a', $user->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/WAFTest.php
+++ b/tests/Endpoints/WAFTest.php
@@ -36,6 +36,7 @@ class WAFTest extends TestCase
 
         $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $waf->getBody()->result[0]->id);
     }
 
     public function testgetPackageInfo()
@@ -55,6 +56,7 @@ class WAFTest extends TestCase
         $result = $waf->getPackageInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b');
 
         $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $result->id);
+        $this->assertEquals('a25a9a7e9c00afc1fb2e0245519d725b', $waf->getBody()->result->id);
     }
 
     public function testgetRules()
@@ -85,6 +87,7 @@ class WAFTest extends TestCase
 
         $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('92f17202ed8bd63d69a66b86a49a8f6b', $waf->getBody()->result[0]->id);
     }
 
     public function testgetRuleInfo()
@@ -104,6 +107,7 @@ class WAFTest extends TestCase
         $result = $waf->getRuleInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'f939de3be84e66e757adcdcb87908023');
 
         $this->assertEquals('f939de3be84e66e757adcdcb87908023', $result->id);
+        $this->assertEquals('f939de3be84e66e757adcdcb87908023', $waf->getBody()->result->id);
     }
 
     public function testupdateRule()
@@ -132,6 +136,7 @@ class WAFTest extends TestCase
         foreach ($details as $property => $value) {
             $this->assertEquals($result->{ $property }, $value);
         }
+        $this->assertEquals('f939de3be84e66e757adcdcb87908023', $waf->getBody()->result->id);
     }
 
     public function getGroups()
@@ -162,6 +167,7 @@ class WAFTest extends TestCase
 
         $this->assertEquals('de677e5818985db1285d0e80225f06e5', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $waf->getBody()->result[0]->id);
     }
 
     public function testgetGroupInfo()
@@ -181,6 +187,7 @@ class WAFTest extends TestCase
         $result = $waf->getGroupInfo('023e105f4ecef8ad9ca31a8372d0c353', 'a25a9a7e9c00afc1fb2e0245519d725b', 'de677e5818985db1285d0e80225f06e5');
 
         $this->assertEquals('de677e5818985db1285d0e80225f06e5', $result->id);
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $waf->getBody()->result->id);
     }
 
     public function testupdateGroup()
@@ -209,5 +216,6 @@ class WAFTest extends TestCase
         foreach ($details as $property => $value) {
             $this->assertEquals($result->{ $property }, $value);
         }
+        $this->assertEquals('de677e5818985db1285d0e80225f06e5', $waf->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/ZoneLockdownTest.php
+++ b/tests/Endpoints/ZoneLockdownTest.php
@@ -33,6 +33,7 @@ class ZoneLockdownTest extends TestCase
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zones->getBody()->result[0]->id);
     }
 
     public function testAddLockdown()
@@ -65,6 +66,7 @@ class ZoneLockdownTest extends TestCase
             '372e67954025e0ba6aaa6d586b9e0b59',
             'Restrict access to these endpoints to requests from a known IP address'
         );
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zoneLockdown->getBody()->result->id);
     }
 
     public function testGetRecordDetails()
@@ -84,6 +86,7 @@ class ZoneLockdownTest extends TestCase
         $result = $lockdown->getLockdownDetails('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
 
         $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $result->id);
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $lockdown->getBody()->result->id);
     }
 
     public function testUpdateLockdown()
@@ -116,6 +119,7 @@ class ZoneLockdownTest extends TestCase
             $config,
             'Restrict access to these endpoints to requests from a known IP address'
         );
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zoneLockdown->getBody()->result->id);
     }
 
     public function testDeleteLockdown()
@@ -136,5 +140,6 @@ class ZoneLockdownTest extends TestCase
 
         $zoneLockdown = new \Cloudflare\API\Endpoints\ZoneLockdown($mock);
         $zoneLockdown->deleteLockdown('023e105f4ecef8ad9ca31a8372d0c353', '372e67954025e0ba6aaa6d586b9e0b59');
+        $this->assertEquals('372e67954025e0ba6aaa6d586b9e0b59', $zoneLockdown->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -234,5 +234,6 @@ class ZonesTest extends TestCase
         ]);
 
         $this->assertTrue($result);
+        $this->assertEquals('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', $zones->getBody()->result->id);
     }
 }

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -210,4 +210,29 @@ class ZonesTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testCachePurge()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/cachePurge.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('delete')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
+                $this->equalTo(['files' => [
+                    'https://example.com/file.jpg',
+                    ]
+                ])
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\Zones($mock);
+        $result = $zones->cachePurge('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', [
+            'https://example.com/file.jpg',
+        ]);
+
+        $this->assertTrue($result);
+    }
 }

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -46,6 +46,7 @@ class ZonesTest extends TestCase
 
         $zones = new \Cloudflare\API\Endpoints\Zones($mock);
         $zones->addZone('example.com', true, '01a7362d577a6c3019a474fd6f485823');
+        $this->assertEquals('9a7806061c88ada191ed06f989cc3dac', $zones->getBody()->result->id);
     }
 
     public function testActivationTest()
@@ -65,6 +66,7 @@ class ZonesTest extends TestCase
         $result = $zones->activationCheck('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
 
         $this->assertTrue($result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
     }
 
     public function testListZones()
@@ -97,6 +99,7 @@ class ZonesTest extends TestCase
 
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result[0]->id);
     }
 
     public function testGetZoneID()
@@ -122,6 +125,7 @@ class ZonesTest extends TestCase
         $result = $zones->getZoneID('example.com');
 
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result[0]->id);
     }
 
     public function testGetAnalyticsDashboard()
@@ -163,6 +167,7 @@ class ZonesTest extends TestCase
         $result = $zones->changeDevelopmentMode('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', true);
 
         $this->assertTrue($result);
+        $this->assertEquals('development_mode', $zones->getBody()->result->id);
     }
 
     public function testCachePurgeEverything()
@@ -183,6 +188,7 @@ class ZonesTest extends TestCase
         $result = $zones->cachePurgeEverything('c2547eb745079dac9320b638f5e225cf483cc5cfdda41');
 
         $this->assertTrue($result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
     }
 
     public function testCachePurgeHost()
@@ -209,6 +215,7 @@ class ZonesTest extends TestCase
         $result = $zones->cachePurge('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', [], [], ['dash.cloudflare.com']);
 
         $this->assertTrue($result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
     }
 
     public function testCachePurge()
@@ -234,6 +241,6 @@ class ZonesTest extends TestCase
         ]);
 
         $this->assertTrue($result);
-        $this->assertEquals('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', $zones->getBody()->result->id);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
     }
 }

--- a/tests/Fixtures/Endpoints/cachePurge.json
+++ b/tests/Fixtures/Endpoints/cachePurge.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353"
+  }
+}

--- a/tests/Fixtures/Endpoints/cachePurge.json
+++ b/tests/Fixtures/Endpoints/cachePurge.json
@@ -3,6 +3,6 @@
   "errors": [],
   "messages": [],
   "result": {
-    "id": "023e105f4ecef8ad9ca31a8372d0c353"
+    "id": "c2547eb745079dac9320b638f5e225cf483cc5cfdda41"
   }
 }

--- a/tests/Fixtures/Endpoints/cachePurge.json
+++ b/tests/Fixtures/Endpoints/cachePurge.json
@@ -3,6 +3,6 @@
   "errors": [],
   "messages": [],
   "result": {
-    "id": "c2547eb745079dac9320b638f5e225cf483cc5cfdda41"
+    "id": "023e105f4ecef8ad9ca31a8372d0c353"
   }
 }


### PR DESCRIPTION
I found myself needing to access the body for a few responses. Since some of the methods only return a boolean value, it was difficult to debug what was happening.

I created the `BodyAccessorTrait`. It adds a private `$body` property. It also adds a `getBody()` method. I added this trait to each class and made each method set the property from the response. There are also new assertions on the existing tests that check the return of the `getBody()` method.

Please let me know if I need to change anything to get this pull request merged. Thanks!