### PR TITLE
Fix SSL configuration method

### DIFF
--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -261,7 +261,7 @@ class PageRulesActions implements Configurations
             throw new ConfigurationsException('Can only be set to off, flexible, full, strict, origin_pull.');
         }
 
-        $this->addConfigurationOption('smart_errors', [
+        $this->addConfigurationOption('ssl', [
             'value' => $value
         ]);
     }


### PR DESCRIPTION
The `setSSL` method in the `PageRulesActions` configuration class seems to be using the wrong config string as mentioned in #72.

Closes #72