### PR TITLE
Feature: add getZoneById method

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -58,6 +58,15 @@ class Zones implements API
         return false;
     }
 
+    public function getZoneById(
+        string $zoneId
+    ): \stdClass {
+        $user = $this->adapter->get('zones/' . $zoneId);
+        $this->body = json_decode($user->getBody());
+
+        return (object)['result' => $this->body->result];
+    }
+
     public function listZones(
         string $name = '',
         string $status = '',

--- a/tests/Endpoints/ZonesTest.php
+++ b/tests/Endpoints/ZonesTest.php
@@ -102,6 +102,25 @@ class ZonesTest extends TestCase
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result[0]->id);
     }
 
+    public function testGetZoneByID()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getZoneById.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('get')->willReturn($response);
+
+        $mock->expects($this->once())
+             ->method('get')
+             ->with($this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353'));
+
+        $zones = new \Cloudflare\API\Endpoints\Zones($mock);
+        $result = $zones->getZoneById('023e105f4ecef8ad9ca31a8372d0c353');
+
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
+        $this->assertEquals('example.com', $zones->getBody()->result->name);
+    }
+
     public function testGetZoneID()
     {
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/getZoneId.json');

--- a/tests/Fixtures/Endpoints/getZoneById.json
+++ b/tests/Fixtures/Endpoints/getZoneById.json
@@ -1,0 +1,59 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "023e105f4ecef8ad9ca31a8372d0c353",
+    "name": "example.com",
+    "development_mode": 7200,
+    "original_name_servers": [
+      "ns1.originaldnshost.com",
+      "ns2.originaldnshost.com"
+    ],
+    "original_registrar": "GoDaddy",
+    "original_dnshost": "NameCheap",
+    "created_on": "2014-01-01T05:20:00.12345Z",
+    "modified_on": "2014-01-01T05:20:00.12345Z",
+    "activated_on": "2014-01-02T00:01:00.12345Z",
+    "owner": {
+      "id": "7c5dae5552338874e5053f2534d2767a",
+      "email": "user@example.com",
+      "type": "user"
+    },
+    "account": {
+      "id": "01a7362d577a6c3019a474fd6f485823",
+      "name": "Demo Account"
+    },
+    "permissions": [
+      "#zone:read",
+      "#zone:edit"
+    ],
+    "plan": {
+      "id": "e592fd9519420ba7405e1307bff33214",
+      "name": "Pro Plan",
+      "price": 20,
+      "currency": "USD",
+      "frequency": "monthly",
+      "legacy_id": "pro",
+      "is_subscribed": true,
+      "can_subscribe": true
+    },
+    "plan_pending": {
+      "id": "e592fd9519420ba7405e1307bff33214",
+      "name": "Pro Plan",
+      "price": 20,
+      "currency": "USD",
+      "frequency": "monthly",
+      "legacy_id": "pro",
+      "is_subscribed": true,
+      "can_subscribe": true
+    },
+    "status": "active",
+    "paused": false,
+    "type": "full",
+    "name_servers": [
+      "tony.ns.cloudflare.com",
+      "woz.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
While working on an implementation, I noticed there is no method in Zones endpoint to get a specific zones' details. This method fixes this by adding a `getZoneById($zoneId)` to `\Cloudflare\API\Endpoints\Zones`.

No documentation changes, because I don't think there is anything to append/change.
Not 100% sure if I did the tests correctly, if anything is wrong or incomplete, let me know and I will update the PR.