### PR TITLE
Adding new Firewall rules Class

### DIFF
--- a/src/Configurations/FirewallRuleOptions.php
+++ b/src/Configurations/FirewallRuleOptions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Cloudflare\API\Configurations;
+
+class FirewallRuleOptions implements Configurations
+{
+    protected $configs = [
+        'paused' => false,
+        'action' => 'block'
+    ];
+
+    public function getArray(): array
+    {
+        return $this->configs;
+    }
+
+    public function setPaused(bool $paused)
+    {
+        $this->configs['paused'] = $paused;
+    }
+
+    public function setActionBlock()
+    {
+        $this->configs['action'] = 'block';
+    }
+
+    public function setActionAllow()
+    {
+        $this->configs['action'] = 'allow';
+    }
+
+    public function setActionChallenge()
+    {
+        $this->configs['action'] = 'challenge';
+    }
+
+    public function setActionJsChallenge()
+    {
+        $this->configs['action'] = 'js_challenge';
+    }
+
+    public function setActionLog()
+    {
+        $this->configs['action'] = 'log';
+    }
+}

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -55,7 +55,7 @@ class Firewall implements API
         string $zoneID,
         int $page = 1,
         int $perPage = 50
-    ): array {
+    ): \stdClass {
         $query = [
             'page' => $page,
             'per_page' => $perPage,
@@ -64,7 +64,7 @@ class Firewall implements API
         $rules = $this->adapter->get('zones/' . $zoneID . '/firewall/rules', $query);
         $body = json_decode($rules->getBody());
 
-        return $body->result;
+        return (object)['result' => $body->result, 'result_info' => $body->result_info];
     }
 
     public function deleteFirewallRule(

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -81,4 +81,39 @@ class Firewall implements API
 
         return false;
     }
+
+    public function updateFirewallRule(
+        string $zoneID,
+        string $ruleID,
+        string $filterID,
+        string $expression,
+        string $action,
+        string $description = null,
+        bool $paused = true,
+        int $priority = null
+    ): \stdClass {
+        $rule = [
+            'id' => $ruleID,
+            'filter' => [
+                'id' => $filterID,
+                'expression' => $expression,
+                'paused' => false
+            ],
+            'action' => $action,
+            'paused' => $paused
+        ];
+
+        if ($description !== null) {
+            $rule['description'] = $description;
+        }
+
+        if ($priority !== null) {
+            $rule['priority'] = $priority;
+        }
+
+        $rule = $this->adapter->put('zones/' . $zoneID . '/firewall/rules/' . $ruleID, $rule);
+        $body = json_decode($rule->getBody());
+
+        return $body->result;
+    }
 }

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -3,6 +3,7 @@
 namespace Cloudflare\API\Endpoints;
 
 use Cloudflare\API\Adapter\Adapter;
+use Cloudflare\API\Configurations\FirewallRuleOptions;
 
 class Firewall implements API
 {
@@ -32,19 +33,16 @@ class Firewall implements API
     public function createFirewallRule(
         string $zoneID,
         string $expression,
-        string $action,
+        FirewallRuleOptions $options,
         string $description = null,
-        bool $paused = false,
         int $priority = null
     ): bool {
-        $rule = [
+        $rule = array_merge([
             'filter' => [
                 'expression' => $expression,
                 'paused' => false
-            ],
-            'action' => $action,
-            'paused' => $paused
-        ];
+            ]
+        ], $options->getArray());
 
         if ($description !== null) {
             $rule['description'] = $description;
@@ -93,21 +91,18 @@ class Firewall implements API
         string $ruleID,
         string $filterID,
         string $expression,
-        string $action,
+        FirewallRuleOptions $options,
         string $description = null,
-        bool $paused = true,
         int $priority = null
     ): \stdClass {
-        $rule = [
+        $rule = array_merge([
             'id' => $ruleID,
             'filter' => [
                 'id' => $filterID,
                 'expression' => $expression,
                 'paused' => false
-            ],
-            'action' => $action,
-            'paused' => $paused
-        ];
+            ]
+        ], $options->getArray());
 
         if ($description !== null) {
             $rule['description'] = $description;

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -16,11 +16,17 @@ class Firewall implements API
     public function createFirewallRules(
         string $zoneID,
         array $rules
-    ): array {
+    ): bool {
         $query = $this->adapter->post('zones/' . $zoneID . '/firewall/rules', $rules);
         $body = json_decode($query->getBody());
 
-        return $body->result;
+        foreach ($body->result as $result) {
+            if (!isset($result->id)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function createFirewallRule(
@@ -30,7 +36,7 @@ class Firewall implements API
         string $description = null,
         bool $paused = false,
         int $priority = null
-    ): array {
+    ): bool {
         $rule = [
             'filter' => [
                 'expression' => $expression,

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Cloudflare\API\Endpoints;
+
+use Cloudflare\API\Adapter\Adapter;
+
+class Firewall implements API
+{
+    private $adapter;
+
+    public function __construct(Adapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    public function createFirewallRules(
+        string $zoneID,
+        array $rules
+    ): array {
+        $query = $this->adapter->post('zones/' . $zoneID . '/firewall/rules', $rules);
+        $body = json_decode($query->getBody());
+
+        return $body->result;
+    }
+
+    public function createFirewallRule(
+        string $zoneID,
+        string $expression,
+        string $action,
+        string $description = null,
+        bool $paused = true,
+        int $priority = null
+    ): array {
+        $rule = [
+            'filter' => [
+                'expression' => $expression,
+                'paused' => false
+            ],
+            'action' => $action,
+            'paused' => $paused
+        ];
+
+        if ($description !== null) {
+            $options['description'] = $description;
+        }
+
+        if ($priority !== null) {
+            $options['priority'] = $priority;
+        }
+
+        return $this->createFirewallRules($zoneID, [$rule]);
+    }
+
+    public function listFirewallRules(
+        string $zoneID,
+        int $page = 1,
+        int $perPage = 50
+    ): array {
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+        ];
+
+        $rules = $this->adapter->get('zones/' . $zoneID . '/firewall/rules', $query);
+        $body = json_decode($rules->getBody());
+
+        return $body->result;
+    }
+
+    public function deleteFirewallRule(
+        string $zoneID,
+        string $ruleID
+    ): bool {
+        $rule = $this->adapter->delete('zones/' . $zoneID . '/firewall/rules/' . $ruleID);
+
+        $body = json_decode($rule->getBody());
+
+        if (isset($body->result->id)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -28,7 +28,7 @@ class Firewall implements API
         string $expression,
         string $action,
         string $description = null,
-        bool $paused = true,
+        bool $paused = false,
         int $priority = null
     ): array {
         $rule = [

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -41,11 +41,11 @@ class Firewall implements API
         ];
 
         if ($description !== null) {
-            $options['description'] = $description;
+            $rule['description'] = $description;
         }
 
         if ($priority !== null) {
-            $options['priority'] = $priority;
+            $rule['priority'] = $priority;
         }
 
         return $this->createFirewallRules($zoneID, [$rule]);

--- a/tests/Endpoints/FirewallTest.php
+++ b/tests/Endpoints/FirewallTest.php
@@ -1,0 +1,177 @@
+<?php
+
+class FirewallTest extends TestCase
+{
+    public function testCreatePageRules()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createFirewallRules.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/rules'),
+                $this->equalTo([
+                    [
+                        'action' => 'block',
+                        'description' => 'Foo',
+                        'filter' => [
+                            'expression' => 'http.cookie eq "foo"',
+                            'paused' => false
+                        ],
+                    ],
+                    [
+                        'action' => 'block',
+                        'description' => 'Bar',
+                        'filter' => [
+                            'expression' => 'http.cookie eq "bar"',
+                            'paused' => false
+                        ],
+                    ]
+                ])
+            );
+
+        $firewall = new Cloudflare\API\Endpoints\Firewall($mock);
+        $result = $firewall->createFirewallRules(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            [
+                [
+                    'filter' => [
+                        'expression' => 'http.cookie eq "foo"',
+                        'paused' => false
+                    ],
+                    'action' => 'block',
+                    'description' => 'Foo'
+                ],
+                [
+                    'filter' => [
+                        'expression' => 'http.cookie eq "bar"',
+                        'paused' => false
+                    ],
+                    'action' => 'block',
+                    'description' => 'Bar'
+                ],
+            ]
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testCreatePageRule()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createFirewallRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/rules'),
+                $this->equalTo([
+                    [
+                        'action' => 'block',
+                        'description' => 'Foobar',
+                        'filter' => [
+                            'expression' => 'http.cookie eq "foobar"',
+                            'paused' => false
+                        ],
+                        'paused' => false
+                    ]
+                ])
+            );
+
+        $firewall = new Cloudflare\API\Endpoints\Firewall($mock);
+        $options = new \Cloudflare\API\Configurations\FirewallRuleOptions();
+        $options->setActionBlock();
+        $result = $firewall->createFirewallRule(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            'http.cookie eq "foobar"',
+            $options,
+            'Foobar'
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testListFirewallRules()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/listFirewallRules.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('get')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/rules'),
+                $this->equalTo([
+                    'page' => 1,
+                    'per_page' => 50
+                ])
+            );
+
+        $firewall = new Cloudflare\API\Endpoints\Firewall($mock);
+        $result = $firewall->listFirewallRules('023e105f4ecef8ad9ca31a8372d0c353');
+
+        $this->assertObjectHasAttribute('result', $result);
+        $this->assertObjectHasAttribute('result_info', $result);
+
+        $this->assertEquals('970b10321e3f4adda674c912b5f76591', $result->result[0]->id);
+    }
+
+    public function testDeleteFirewallRule()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/deleteFirewallRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('delete')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/rules/970b10321e3f4adda674c912b5f76591')
+            );
+
+        $firewall = new Cloudflare\API\Endpoints\Firewall($mock);
+        $firewall->deleteFirewallRule('023e105f4ecef8ad9ca31a8372d0c353', '970b10321e3f4adda674c912b5f76591');
+    }
+
+    public function testUpdateFirewallRule()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateFirewallRule.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('put')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/firewall/rules/970b10321e3f4adda674c912b5f76591'),
+                $this->equalTo([
+                    'id' => '970b10321e3f4adda674c912b5f76591',
+                    'action' => 'block',
+                    'description' => 'Foo',
+                    'filter' => [
+                        'id' => '5def9c4297e0466cb0736b838345d910',
+                        'expression' => 'http.cookie eq "foo"',
+                        'paused' => false
+                    ],
+                    'paused' => false
+                ])
+            );
+
+        $firewall = new Cloudflare\API\Endpoints\Firewall($mock);
+        $options = new \Cloudflare\API\Configurations\FirewallRuleOptions();
+        $options->setActionBlock();
+        $result = $firewall->updateFirewallRule(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            '970b10321e3f4adda674c912b5f76591',
+            '5def9c4297e0466cb0736b838345d910',
+            'http.cookie eq "foo"',
+            $options,
+            'Foo'
+        );
+        $this->assertEquals('970b10321e3f4adda674c912b5f76591', $result->id);
+    }
+}

--- a/tests/Fixtures/Endpoints/createFirewallRule.json
+++ b/tests/Fixtures/Endpoints/createFirewallRule.json
@@ -1,0 +1,20 @@
+{
+  "result": [
+    {
+      "id": "970b10321e3f4adda674c912b5f76591",
+      "paused": false,
+      "description": "Foobar",
+      "action": "block",
+      "filter": {
+        "id": "70f39827184d487e97cc286b960f4cc3",
+        "expression": "http.cookie eq \"foobar\"",
+        "paused": false
+      },
+      "created_on": "2019-07-05T15:53:15Z",
+      "modified_on": "2019-07-05T15:53:15Z"
+    }
+  ],
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/Fixtures/Endpoints/createFirewallRules.json
+++ b/tests/Fixtures/Endpoints/createFirewallRules.json
@@ -1,0 +1,33 @@
+{
+  "result": [
+    {
+      "id": "970b10321e3f4adda674c912b5f76591",
+      "paused": false,
+      "description": "Foo",
+      "action": "block",
+      "filter": {
+        "id": "70f39827184d487e97cc286b960f4cc3",
+        "expression": "http.cookie eq \"foo\"",
+        "paused": false
+      },
+      "created_on": "2019-07-05T15:53:15Z",
+      "modified_on": "2019-07-05T15:53:15Z"
+    },
+    {
+      "id": "42c05fd0e0af4d17a361d2d1423476bc",
+      "paused": false,
+      "description": "Bar",
+      "action": "block",
+      "filter": {
+        "id": "246b4d9f5f51471485bdc95e1c6b53a7",
+        "expression": "http.cookie eq \"bar\"",
+        "paused": false
+      },
+      "created_on": "2019-07-05T15:53:15Z",
+      "modified_on": "2019-07-05T15:53:15Z"
+    }
+  ],
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/Fixtures/Endpoints/deleteFirewallRule.json
+++ b/tests/Fixtures/Endpoints/deleteFirewallRule.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "id": "970b10321e3f4adda674c912b5f76591"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/Fixtures/Endpoints/listFirewallRules.json
+++ b/tests/Fixtures/Endpoints/listFirewallRules.json
@@ -1,0 +1,27 @@
+{
+  "result": [
+    {
+      "id": "970b10321e3f4adda674c912b5f76591",
+      "paused": false,
+      "description": "Foobar",
+      "action": "block",
+      "filter": {
+        "id": "70f39827184d487e97cc286b960f4cc3",
+        "expression": "http.cookie eq \"foobar\"",
+        "paused": false
+      },
+      "created_on": "2019-07-05T15:53:15Z",
+      "modified_on": "2019-07-05T15:53:15Z"
+    }
+  ],
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result_info": {
+    "page": 1,
+    "per_page": 50,
+    "count": 1,
+    "total_count": 1,
+    "total_pages": 1
+  }
+}

--- a/tests/Fixtures/Endpoints/updateFirewallRule.json
+++ b/tests/Fixtures/Endpoints/updateFirewallRule.json
@@ -1,0 +1,19 @@
+{
+  "result": {
+    "id": "970b10321e3f4adda674c912b5f76591",
+    "paused": false,
+    "description": "Foo",
+    "action": "block",
+    "filter": {
+      "id": "5def9c4297e0466cb0736b838345d910",
+      "expression": "http.cookie eq \"foo\"",
+      "paused": false
+    },
+    "created_on": "2019-07-05T15:53:15Z",
+    "modified_on": "2019-07-05T18:07:46Z",
+    "index": 1
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}


### PR DESCRIPTION
We added a couple new classes to control Firewall rules in Cloudflare. This is useful for creating application side logic to update rules directly in Cloudflare. Our use case was Blocking all POST routes and then adding Allow rule for only the specific POST routes that were valid. By doing this in the Cloudflare Firewall we have seen a decrease in server load and an increase in application stability. 

We have added a unit test for the Firewall Endpoint class. We did not add a unit test for the Options class because none of the other Options classes had them. Happy to add additional unit tests for this class we added as part of a future pull request. 

We have tested that our changes are working by including the source from our fork directly in our production application. It will be nice to get this accepted into master so that we do not need to maintain the code in our fork. We have some other things we would like to open source that are Application specific libraries that are dependent on getting this into master. 

---
The new Firewall class does the following things. 

createFirewallRules - Adds one or more firewall rules at a time to Cloudflare. This method actually sets the Rules in Cloudflare. It is used internally in the class by createFirewallRule. It has slightly different method signature that takes in an array of rules that should be set. The array can be one or more rules in it. Returns false if there was a problem adding any of the rules. 

createFirewallRule - Adds new firewall rules to Cloudflare. This only adds one rule at a time. You need to set the FirewallRuleOptions object before calling this method. The FirewallRuleOptions defines the Action and if the Rule should be Paused or not. 

listFirewallRules - Lists the existing Firewall rules. This is used on the application side to get list of rules so you can check if the rule exists yet or not before it a new one is added. 

deleteFirewallRule - Deletes an existing Firewall rule. You need to know ruleId before calling this method and you can get this from the listFirewallRules method call. 

updateFirewallRule - Updates an existing Firewall rule. You need to know ruleId before calling this method and you can get this from the listFirewallRules method call. You need to set the FirewallRuleOptions object before calling this method. The FirewallRuleOptions defines the Action and if the Rule should be Paused or not. 

---

The FirewallRuleOptions contains methods to block, challenge, JSchallenge and Log. It also contains ability to control draft or published via the setPaused method. 



