### PR TITLE
Add Export DNS endpoint

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -85,7 +85,9 @@ class Guzzle implements Adapter
             ($method === 'get' ? 'query' : 'json') => $data,
         ]);
 
-        $this->checkError($response);
+        if (strpos($uri, 'export') === false) {
+            $this->checkError($response);
+        }
 
         return $response;
     }

--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -59,7 +59,7 @@ class DNS implements API
         if (!empty($priority)) {
             $options['priority'] = (int)$priority;
         }
-        
+
         if (!empty($data)) {
             $options['data'] = $data;
         }
@@ -153,4 +153,12 @@ class DNS implements API
 
         return false;
     }
+
+    public function export(string $zoneID) : string
+    {
+        $response = $this->adapter->get('zones/' . $zoneID . '/dns_records/export');
+
+        return $response->getBody()->getContents();
+    }
+
 }


### PR DESCRIPTION
Adds in the ability to export a zone file by zoneID.

As the request function expects a json response, there is a strpos on the uri to ensure it is not the export endpoint.

Not as neat as I'd like it, so if there is a suggestion for a better way please let me know.