### PR TITLE
Fix PageRulesActions: setResolveOverride,setHostHeaderOverride

### DIFF
--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -140,10 +140,10 @@ class PageRulesActions implements Configurations
         ]);
     }
 
-    public function setHostHeaderOverride(bool $active)
+    public function setHostHeaderOverride(string $value)
     {
         $this->addConfigurationOption('host_header_override', [
-            'value' => $this->getBoolAsOnOrOff($active)
+            'value' => $value
         ]);
     }
 
@@ -198,7 +198,7 @@ class PageRulesActions implements Configurations
         ]);
     }
 
-    public function setResolveOverride(bool $value)
+    public function setResolveOverride(string $value)
     {
         $this->addConfigurationOption('resolve_override', [
             'value' => $value


### PR DESCRIPTION
Hello!

Great library, thank you!

I had to set up page rules & DNS records across 5+ domains for a new set of development environments that run via Cloudflare and this saved so much time compared to the web UI!!

This includes fixes for `PageRulesActions::setResolveOverride` and `PageRulesActions::setHostHeaderOverride`.

Both are Enterprise only features that take a string, but the library is only allowing a bool value for each, so I had to modify the code locally to make it work.

Hopefully this'll be helpful for somebody else too.

Regards,
iamacarpet