### PR TITLE
Maximum value of Edge Cache TTL

### DIFF
--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -117,7 +117,7 @@ class PageRulesActions implements Configurations
 
     public function setEdgeCacheTTL(int $value)
     {
-        if ($value > 2419200) {
+        if ($value > 2678400) {
             throw new ConfigurationsException('Edge Cache TTL too high.');
         }
 


### PR DESCRIPTION
It is possible to choose a month value, so the value parameter can be greater