### PR TITLE
Add Browser Cache TTL Setting Endpoints, Tests

### DIFF
--- a/src/Endpoints/ZoneSettings.php
+++ b/src/Endpoints/ZoneSettings.php
@@ -106,6 +106,37 @@ class ZoneSettings implements API
         return false;
     }
 
+    public function getBrowserCacheTtlSetting($zoneID)
+    {
+        $return = $this->adapter->get(
+            'zones/' . $zoneID . '/settings/browser_cache_ttl'
+        );
+        $body   = json_decode($return->getBody());
+
+        if ($body->success) {
+            return $body->result->value;
+        }
+
+        return false;
+    }
+
+    public function updateBrowserCacheTtlSetting($zoneID, $value)
+    {
+        $return = $this->adapter->patch(
+            'zones/' . $zoneID . '/settings/browser_cache_ttl',
+            [
+                'value' => $value
+            ]
+        );
+        $body   = json_decode($return->getBody());
+
+        if ($body->success) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function updateMinifySetting($zoneID, $html, $css, $javascript)
     {
         $return = $this->adapter->patch(

--- a/tests/Endpoints/ZoneSettingsTest.php
+++ b/tests/Endpoints/ZoneSettingsTest.php
@@ -36,4 +36,34 @@ class ZoneSettingsTest extends TestCase
 
         $this->assertSame('on', $result);
     }
+
+    public function testGetBrowserCacheTtlSetting()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getBrowserCacheTtlSetting.json');
+
+        $mock = $this->getMockBuilder(Adapter::class)->getMock();
+        $mock->method('get')->willReturn($response);
+
+        $mock->expects($this->once())->method('get');
+
+        $zones = new ZoneSettings($mock);
+        $result = $zones->getBrowserCacheTtlSetting('023e105f4ecef8ad9ca31a8372d0c353');
+
+        $this->assertSame(14400, $result);
+    }
+
+    public function testUpdateBrowserCacheTtlSetting()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/updateBrowserCacheTtlSetting.json');
+
+        $mock = $this->getMockBuilder(Adapter::class)->getMock();
+        $mock->method('patch')->willReturn($response);
+
+        $mock->expects($this->once())->method('patch');
+
+        $zones = new ZoneSettings($mock);
+        $result = $zones->updateBrowserCacheTtlSetting('023e105f4ecef8ad9ca31a8372d0c353', 16070400);
+
+        $this->assertTrue($result);
+    }
 }

--- a/tests/Fixtures/Endpoints/getBrowserCacheTtlSetting.json
+++ b/tests/Fixtures/Endpoints/getBrowserCacheTtlSetting.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "browser_cache_ttl",
+    "value": 14400,
+    "editable": true,
+    "modified_on": "2014-01-01T05:20:00.12345Z"
+  }
+}

--- a/tests/Fixtures/Endpoints/updateBrowserCacheTtlSetting.json
+++ b/tests/Fixtures/Endpoints/updateBrowserCacheTtlSetting.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "browser_cache_ttl",
+    "value": 14400,
+    "editable": true,
+    "modified_on": "2014-01-01T05:20:00.12345Z"
+  }
+}


### PR DESCRIPTION
Hi there,

New functions added ,Tests
- `getBrowserCacheTtlSetting`
- `updateBrowserCacheTtlSetting`
