### PR TITLE
Add custom hostname options

### DIFF
--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -143,9 +143,11 @@ class CustomHostnames implements API
             $query['settings'] = $sslSettings;
         }
 
-        $options = [
-            'ssl' => $query
-        ];
+        if (!empty($query)) {
+            $options = [
+                'ssl' => $query
+            ];
+        }
 
         if (!empty($customOriginServer)) {
             $options['custom_origin_server'] = $customOriginServer;

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -31,9 +31,11 @@ class CustomHostnames implements API
      * @param string $sslMethod
      * @param string $sslType
      * @param array $sslSettings
+     * @param string $customOriginServer
+     * @param bool $wildcard
      * @return \stdClass
      */
-    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = ''): \stdClass
+    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = '', bool $wildcard = false): \stdClass
     {
         $options = [
             'hostname' => $hostname,
@@ -41,7 +43,8 @@ class CustomHostnames implements API
                 'method' => $sslMethod,
                 'type' => $sslType,
                 'settings' => $sslSettings
-            ]
+            ],
+            'wildcard' => $wildcard,
         ];
 
         if (!empty($customOriginServer)) {

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -33,7 +33,7 @@ class CustomHostnames implements API
      * @param array $sslSettings
      * @return \stdClass
      */
-    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = []): \stdClass
+    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = ''): \stdClass
     {
         $options = [
             'hostname' => $hostname,
@@ -43,6 +43,10 @@ class CustomHostnames implements API
                 'settings' => $sslSettings
             ]
         ];
+
+        if (!empty($customOriginServer)) {
+            $options['custom_origin_server'] = $customOriginServer;
+        }
 
         $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);
         $this->body = json_decode($zone->getBody());
@@ -120,7 +124,7 @@ class CustomHostnames implements API
      * @param string $sslType
      * @return \stdClass
      */
-    public function updateHostname(string $zoneID, string $hostnameID, string $sslMethod = '', string $sslType = '', array $sslSettings = []): \stdClass
+    public function updateHostname(string $zoneID, string $hostnameID, string $sslMethod = '', string $sslType = '', array $sslSettings = [], string $customOriginServer = ''): \stdClass
     {
         $query = [];
 
@@ -139,6 +143,10 @@ class CustomHostnames implements API
         $options = [
             'ssl' => $query
         ];
+
+        if (!empty($customOriginServer)) {
+            $options['custom_origin_server'] = $customOriginServer;
+        }
 
         $zone = $this->adapter->patch('zones/'.$zoneID.'/custom_hostnames/'.$hostnameID, $options);
         $this->body = json_decode($zone->getBody());

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -30,15 +30,17 @@ class CustomHostnames implements API
      * @param string $hostname
      * @param string $sslMethod
      * @param string $sslType
+     * @param array $sslSettings
      * @return \stdClass
      */
-    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv'): \stdClass
+    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = []): \stdClass
     {
         $options = [
             'hostname' => $hostname,
             'ssl' => [
                 'method' => $sslMethod,
-                'type' => $sslType
+                'type' => $sslType,
+                'settings' => $sslSettings
             ]
         ];
 
@@ -118,7 +120,7 @@ class CustomHostnames implements API
      * @param string $sslType
      * @return \stdClass
      */
-    public function updateHostname(string $zoneID, string $hostnameID, string $sslMethod = '', string $sslType = ''): \stdClass
+    public function updateHostname(string $zoneID, string $hostnameID, string $sslMethod = '', string $sslType = '', array $sslSettings = []): \stdClass
     {
         $query = [];
 
@@ -128,6 +130,10 @@ class CustomHostnames implements API
 
         if (!empty($sslType)) {
             $query['type'] = $sslType;
+        }
+
+        if (!empty($sslSettings)) {
+            $query['settings'] = $sslSettings;
         }
 
         $options = [

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -32,7 +32,8 @@ class CustomHostnamesTest extends TestCase
                             'http3' => 'on',
                             'min_tls_version' => '1.2'
                         ]
-                    ]
+                    ],
+                    'wildcard' => true,
                 ])
             );
 
@@ -42,7 +43,7 @@ class CustomHostnamesTest extends TestCase
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
-        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com');
+        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com', true);
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -23,6 +23,7 @@ class CustomHostnamesTest extends TestCase
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames'),
                 $this->equalTo([
                     'hostname' => 'app.example.com',
+                    'custom_origin_server' => 'origin.example.com',
                     'ssl' => [
                         'method' => 'http',
                         'type' => 'dv',
@@ -41,7 +42,7 @@ class CustomHostnamesTest extends TestCase
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
-        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings);
+        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com');
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 
@@ -111,6 +112,7 @@ class CustomHostnamesTest extends TestCase
             ->with(
                 $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9'),
                 $this->equalTo([
+                    'custom_origin_server' => 'origin.example.com',
                     'ssl' => [
                         'method' => 'http',
                         'type' =>  'dv',
@@ -129,7 +131,7 @@ class CustomHostnamesTest extends TestCase
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
-        $result = $zones->updateHostname('023e105f4ecef8ad9ca31a8372d0c353', '0d89c70d-ad9f-4843-b99f-6cc0252067e9', 'http', 'dv', $sslSettings);
+        $result = $zones->updateHostname('023e105f4ecef8ad9ca31a8372d0c353', '0d89c70d-ad9f-4843-b99f-6cc0252067e9', 'http', 'dv', $sslSettings, 'origin.example.com');
 
         $this->assertObjectHasAttribute('id', $result);
         $this->assertObjectHasAttribute('hostname', $result);

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -25,13 +25,23 @@ class CustomHostnamesTest extends TestCase
                     'hostname' => 'app.example.com',
                     'ssl' => [
                         'method' => 'http',
-                        'type' => 'dv'
+                        'type' => 'dv',
+                        'settings' => [
+                            'http2' => 'on',
+                            'http3' => 'on',
+                            'min_tls_version' => '1.2'
+                        ]
                     ]
                 ])
             );
 
         $hostname = new CustomHostnames($mock);
-        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv');
+        $sslSettings = [
+            'http2' => 'on',
+            'http3' => 'on',
+            'min_tls_version' => '1.2'
+        ];
+        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings);
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 
@@ -103,13 +113,23 @@ class CustomHostnamesTest extends TestCase
                 $this->equalTo([
                     'ssl' => [
                         'method' => 'http',
-                        'type' =>  'dv'
+                        'type' =>  'dv',
+                        'settings' => [
+                            'http2' => 'on',
+                            'http3' => 'on',
+                            'min_tls_version' => '1.2'
+                        ]
                     ]
                 ])
             );
 
         $zones = new \Cloudflare\API\Endpoints\CustomHostnames($mock);
-        $result = $zones->updateHostname('023e105f4ecef8ad9ca31a8372d0c353', '0d89c70d-ad9f-4843-b99f-6cc0252067e9', 'http', 'dv');
+        $sslSettings = [
+            'http2' => 'on',
+            'http3' => 'on',
+            'min_tls_version' => '1.2'
+        ];
+        $result = $zones->updateHostname('023e105f4ecef8ad9ca31a8372d0c353', '0d89c70d-ad9f-4843-b99f-6cc0252067e9', 'http', 'dv', $sslSettings);
 
         $this->assertObjectHasAttribute('id', $result);
         $this->assertObjectHasAttribute('hostname', $result);


### PR DESCRIPTION
Enabled specifying some additional options such as custom origin server, HTTP2 & 3, minimum TLS version, wildcard, etc.
