### PR TITLE
Fix for MX with priority 0

### DIFF
--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -56,7 +56,7 @@ class DNS implements API
             $options['ttl'] = $ttl;
         }
 
-        if (!empty($priority)) {
+        if (is_numeric($priority)) {
             $options['priority'] = (int)$priority;
         }
         

--- a/tests/Endpoints/DNSTest.php
+++ b/tests/Endpoints/DNSTest.php
@@ -32,6 +32,57 @@ class DNSTest extends TestCase
         $dns->addRecord('023e105f4ecef8ad9ca31a8372d0c353', 'A', 'example.com', '127.0.0.1', '120', false);
     }
 
+    public function testAddMXRecordPriority10()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/addRecord.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records'),
+                $this->equalTo([
+                    'type' => 'MX',
+                    'name' => 'example.com',
+                    'content' => '127.0.0.1',
+                    'ttl' => 120,
+                    'proxied' => false,
+            'priority' => 10,
+                ])
+            );
+
+        $dns = new \Cloudflare\API\Endpoints\DNS($mock);
+        $dns->addRecord('023e105f4ecef8ad9ca31a8372d0c353', 'MX', 'example.com', '127.0.0.1', '120', false, 10);
+    }
+
+    public function testAddMXRecordPriority0()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/addRecord.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/dns_records'),
+                $this->equalTo([
+                    'type' => 'MX',
+                    'name' => 'example.com',
+                    'content' => '127.0.0.1',
+                    'ttl' => 120,
+                    'proxied' => false,
+                    'priority' => 0,
+                ])
+            );
+
+        $dns = new \Cloudflare\API\Endpoints\DNS($mock);
+        $dns->addRecord('023e105f4ecef8ad9ca31a8372d0c353', 'MX', 'example.com', '127.0.0.1', '120', false, 0);
+    }
+
+
     public function testListRecords()
     {
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/listRecords.json');


### PR DESCRIPTION
If an MX record is created via addRecord with a priority of 0, an error gets thrown by the api:

```json
{"result":null,"success":false,"errors":[{"code":1004,"message":"DNS Validation Error","error_chain":[{"code":9100,"message":"priority is a required field."}]}],"messages":[]}
```

As the php [empty](https://www.php.net/manual/en/function.empty.php) function matches integers or strings set to 0, this causes the script to think that the priority hasn't been set, which means that $options['priority'] isn't set and subsequently it isn't passed in the post.

The [is_numeric](https://www.php.net/manual/en/function.is-numeric.php) function would fix this as it matches to see if a numeric value has been passed into addRecord for the MX priority.

```php
//if(!empty($priority)) {

if (is_numeric($priority)) {
    $options['priority'] = (int)$priority;
}
```

I've written two tests, one for adding an MX record with priority 10 and one with priority 0. With the original code the priority 10 addition works, but the priority 0 fails. With the change both work.