### PR TITLE
feat(Endpoints\DNS): getRecordID to throw exception like Zones::getZoneID

### DIFF
--- a/src/Endpoints/DNS.php
+++ b/src/Endpoints/DNS.php
@@ -128,10 +128,12 @@ class DNS implements API
     public function getRecordID(string $zoneID, string $type = '', string $name = ''): string
     {
         $records = $this->listRecords($zoneID, $type, $name);
-        if (isset($records->result[0]->id)) {
-            return $records->result[0]->id;
+
+        if (count($records->result) < 1) {
+            throw new EndpointException('Could not find records with specified type and or name.');
         }
-        return false;
+
+        return $records->result[0]->id;
     }
 
     public function updateRecordDetails(string $zoneID, string $recordID, array $details): \stdClass


### PR DESCRIPTION
Feature request to make the Endpoints match how they handle not finding the ID requested.
Throw appears to be the better pattern since the return type. Since previous was returning false and casting it to empty string due to return type, but for better future proof and possible issues with strict mode would be safer to throw.

IMPORTANT: It will break existing logic that is written to expect empty string instead of throw. This change should be included in next major version bump.
