### PR TITLE
Ignoring guzzle http errors

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -29,7 +29,8 @@ class Guzzle implements Adapter
         $this->client = new Client([
             'base_uri' => $baseURI,
             'headers' => $headers,
-            'Accept' => 'application/json'
+            'Accept' => 'application/json',
+            'http_errors' => false
         ]);
     }
 


### PR DESCRIPTION
If cloudflare api returns http code other than 2xx we get a guzzlehttp exception, the checkError function will not be able to execute before the exception