### PR TITLE
Guzzle plaintext response error

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -92,12 +92,11 @@ class Guzzle implements Adapter
 
     private function checkError(ResponseInterface $response)
     {
-
         $body = (string) $response->getBody();
 
         // If first character of the response body is not { then the response is in plain text so need to skip below checks as they fail.
         if (strpos($body, '{') !== 0) {
-          return;
+            return;
         }
 
         $json = json_decode($body);

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -92,7 +92,15 @@ class Guzzle implements Adapter
 
     private function checkError(ResponseInterface $response)
     {
-        $json = json_decode($response->getBody());
+
+        $body = (string) $response->getBody();
+
+        // If first character of the response body is not { then the response is in plain text so need to skip below checks as they fail.
+        if (strpos($body, '{') !== 0) {
+          return;
+        }
+
+        $json = json_decode($body);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new JSONException();


### PR DESCRIPTION
This is a PR to fix the issue raised in https://github.com/cloudflare/cloudflare-php/issues/152 which I've also encountered after applying the patch from https://github.com/cloudflare/cloudflare-php/pull/139 to be able to use the WorkersKV endpoints.

The fix is quite basic and there might be a better of doing this, but from what I can see whenever there's either success or error responses they are always in JSON format, except for the one random endpoint to 'Read key-value pair ' (https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair) which returns the value of the key in plain text.
So to get around that I just checked if the first character of the response is a { or not, and if it's not then skip all the json code below otherwise it fails with a 'json syntax' error since it's a plain text.

I ran all the tests and they passed, however I didn't write a new one as the change is to the Guzzle adapter which already has all the tests.
I guess I could try writing one to cover the 'plain text' response from the API.