### PR TITLE
Make addConfigurationOption public

### DIFF
--- a/src/Configurations/PageRulesActions.php
+++ b/src/Configurations/PageRulesActions.php
@@ -306,7 +306,7 @@ class PageRulesActions implements Configurations
         return $this->configs;
     }
 
-    private function addConfigurationOption(string $setting, array $configuration)
+    public function addConfigurationOption(string $setting, array $configuration)
     {
         $configuration['id'] = $setting;
 


### PR DESCRIPTION
This will allow users to easily add their own configuration when new configuration type has been added by Cloudflare without waiting for a release from the SDK.

Also, this is very useful if you are trying to import configuration from one zone to another as at the moment you would need to call each specific method even though most of them are of the same nature and could be bundled together using the same structure.