### PR TITLE
Add Missing Support For Custom Hostname Properties

### DIFF
--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -55,9 +55,9 @@ class CustomHostnames implements API
             'ssl' => [
                 'method' => $sslMethod,
                 'type' => $sslType,
-                'settings' => $sslSettings
+                'settings' => $sslSettings,
+                'wildcard' => $wildcard,
             ],
-            'wildcard' => $wildcard,
         ];
 
         if (!empty($customOriginServer)) {
@@ -65,15 +65,15 @@ class CustomHostnames implements API
         }
 
         if (empty($bundleMethod) === false) {
-            $options['bundle_method'] = $bundleMethod;
+            $options['ssl']['bundle_method'] = $bundleMethod;
         }
 
         if (empty($customKey) === false) {
-            $options['custom_key'] = $customKey;
+            $options['ssl']['custom_key'] = $customKey;
         }
 
         if (empty($customCertificate) === false) {
-            $options['custom_certificate'] = $customCertificate;
+            $options['ssl']['custom_certificate'] = $customCertificate;
         }
 
         $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -14,7 +14,7 @@ use Cloudflare\API\Traits\BodyAccessorTrait;
 class CustomHostnames implements API
 {
     use BodyAccessorTrait;
-    
+
     private $adapter;
 
     public function __construct(Adapter $adapter)
@@ -30,12 +30,15 @@ class CustomHostnames implements API
      * @param string $hostname
      * @param string $sslMethod
      * @param string $sslType
-     * @param array $sslSettings
+     * @param array  $sslSettings
      * @param string $customOriginServer
-     * @param bool $wildcard
+     * @param bool   $wildcard
+     * @param string $bundleMethod
+     * @param string $customKey
+     * @param string $customCertificate
      * @return \stdClass
      */
-    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = '', bool $wildcard = false): \stdClass
+    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = '', bool $wildcard = false, string $bundleMethod = '', string $customKey = '', string $customCertificate = ''): \stdClass
     {
         $options = [
             'hostname' => $hostname,
@@ -49,6 +52,18 @@ class CustomHostnames implements API
 
         if (!empty($customOriginServer)) {
             $options['custom_origin_server'] = $customOriginServer;
+        }
+
+        if (empty($bundleMethod) === false) {
+            $options['bundle_method'] = $bundleMethod;
+        }
+
+        if (empty($customKey) === false) {
+            $options['custom_key'] = $customKey;
+        }
+
+        if (empty($customCertificate) === false) {
+            $options['custom_certificate'] = $customCertificate;
         }
 
         $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -34,8 +34,7 @@ class CustomHostnames implements API
      * @param string $customOriginServer
      * @param bool   $wildcard
      * @param string $bundleMethod
-     * @param string $customKey
-     * @param string $customCertificate
+     * @param array $customSsl
      * @return \stdClass
      */
     public function addHostname(
@@ -47,8 +46,7 @@ class CustomHostnames implements API
         string $customOriginServer = '',
         bool $wildcard = false,
         string $bundleMethod = '',
-        string $customKey = '',
-        string $customCertificate = ''
+        array $customSsl = []
     ): \stdClass {
         $options = [
             'hostname' => $hostname,
@@ -68,12 +66,12 @@ class CustomHostnames implements API
             $options['ssl']['bundle_method'] = $bundleMethod;
         }
 
-        if (!empty($customKey)) {
-            $options['ssl']['custom_key'] = $customKey;
+        if (!empty($customSsl['key'])) {
+            $options['ssl']['custom_key'] = $customSsl['key'];
         }
 
-        if (!empty($customCertificate)) {
-            $options['ssl']['custom_certificate'] = $customCertificate;
+        if (!empty($customSsl['certificate'])) {
+            $options['ssl']['custom_certificate'] = $customSsl['certificate'];
         }
 
         $zone = $this->adapter->post('zones/'.$zoneID.'/custom_hostnames', $options);

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -38,8 +38,18 @@ class CustomHostnames implements API
      * @param string $customCertificate
      * @return \stdClass
      */
-    public function addHostname(string $zoneID, string $hostname, string $sslMethod = 'http', string $sslType = 'dv', array $sslSettings = [], string $customOriginServer = '', bool $wildcard = false, string $bundleMethod = '', string $customKey = '', string $customCertificate = ''): \stdClass
-    {
+    public function addHostname(
+        string $zoneID,
+        string $hostname,
+        string $sslMethod = 'http',
+        string $sslType = 'dv',
+        array $sslSettings = [],
+        string $customOriginServer = '',
+        bool $wildcard = false,
+        string $bundleMethod = '',
+        string $customKey = '',
+        string $customCertificate = ''
+    ): \stdClass {
         $options = [
             'hostname' => $hostname,
             'ssl' => [

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -64,15 +64,15 @@ class CustomHostnames implements API
             $options['custom_origin_server'] = $customOriginServer;
         }
 
-        if (empty($bundleMethod) === false) {
+        if (!empty($bundleMethod)) {
             $options['ssl']['bundle_method'] = $bundleMethod;
         }
 
-        if (empty($customKey) === false) {
+        if (!empty($customKey)) {
             $options['ssl']['custom_key'] = $customKey;
         }
 
-        if (empty($customCertificate) === false) {
+        if (!empty($customCertificate)) {
             $options['ssl']['custom_certificate'] = $customCertificate;
         }
 

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -47,7 +47,7 @@ bsrBsljYfVvtLQzilugs1oEe94LTrYjR2oQt0W24bqpGQHuv1ILuUBuodERkxSFL
 /cMkj3wSfC341hFaJEuG1+PcxA==
 -----END PRIVATE KEY-----
 KEY;
-    $customCertificate = <<<CERTIFICATE
+        $customCertificate = <<<CERTIFICATE
 -----BEGIN CERTIFICATE-----
 MIIDmTCCAoGgAwIBAgIULyaeNqp0tOut/wvuxNyKmUxOGYEwDQYJKoZIhvcNAQEL
 BQAwXDELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -47,6 +47,7 @@ bsrBsljYfVvtLQzilugs1oEe94LTrYjR2oQt0W24bqpGQHuv1ILuUBuodERkxSFL
 /cMkj3wSfC341hFaJEuG1+PcxA==
 -----END PRIVATE KEY-----
 KEY;
+
         $customCertificate = <<<CERTIFICATE
 -----BEGIN CERTIFICATE-----
 MIIDmTCCAoGgAwIBAgIULyaeNqp0tOut/wvuxNyKmUxOGYEwDQYJKoZIhvcNAQEL
@@ -101,6 +102,7 @@ CERTIFICATE;
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
+
         $hostname->addHostname(
             '023e105f4ecef8ad9ca31a8372d0c353',
             'app.example.com',
@@ -110,8 +112,10 @@ CERTIFICATE;
             'origin.example.com',
             true,
             'optimal',
-            $customKey,
-            $customCertificate
+            [
+                'key' => $customKey,
+                'certificate' => $customCertificate,
+            ]
         );
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -14,10 +14,10 @@ class CustomHostnamesTest extends TestCase
     {
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/createCustomHostname.json');
 
+        $customSsl = $this->getCustomSsl();
+
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
-
-        $customSsl = $this->getCustomSsl();
 
         $mock->expects($this->once())
             ->method('post')

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -85,13 +85,13 @@ CERTIFICATE;
                         'settings' => [
                             'http2' => 'on',
                             'http3' => 'on',
-                            'min_tls_version' => '1.2'
-                        ]
+                            'min_tls_version' => '1.2',
+                        ],
+                        'bundle_method' => 'optimal',
+                        'custom_key' => $customKey,
+                        'custom_certificate' => $customCertificate,
+                        'wildcard' => true,
                     ],
-                    'bundle_method' => 'optimal',
-                    'custom_key' => $customKey,
-                    'custom_certificate' => $customCertificate,
-                    'wildcard' => true,
                 ])
             );
 

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -17,61 +17,7 @@ class CustomHostnamesTest extends TestCase
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
-        $customKey = <<<KEY
------BEGIN PRIVATE KEY-----
-MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDZfoCUkzkZLCzo
-OFTtlXU9OYqNFx06J/GOKCwDCyfkY5RY1x6BVrVpTqf/JaU42DZmCjIiEugBg4bu
-eu9/w21prIWgRKEe8mjrw83+3QSIyQrs+78rqwDptUfL+IyhYln6SBjqPQ569Y0w
-x6A896PDMYPHgnWtclGwsxDNKJ2eWsH+C4UkLUeVM4BILEJ00YUjayowL/0sflTJ
-yY58c9fVV27aGBJ4znreYkBojPQ0fzVZ3HJfYD+DgYUUkuzN/WohOLTNTxvzt/i2
-GNxP8tZzi0E/t4KtGTsIVmROKaCXnmozQyv0VES5TNZL1nxLvVuPca9DKXwVst2o
-v5czEM8fAgMBAAECggEBANgG/aIVpWYqaaRyp3CgviWE7Oh9J+um1xgzMJwJTaNd
-gXDIoyUmweQKW3Vjp/uRTl8GC4uqqcUvJivj8dU+gIOw970bzcmWT7616vsV/rX6
-sp524wh1vt9jzx97DfwSW3rsd8rZwHNDSO1FqxRDiOaNXO4i183iud8/zRVqHTy1
-5girngsGl7ebTt3LDHDQQ86kND2nVr8xZuFaqs8Td41AsF6DGbB709wMUqoM/obO
-iUtXCZ5Rrm2a78OUi0cqWsuxdhJjtOW0PBvrPTlSq+1EuQWAWV8HN1JI58YnLcLy
-SKZpsu5wxWdKMgX0NCkfLjDZCAPlBaZLPPp986GHavECgYEA8hM6tIfGBnXuxBvI
-y2lJG3sHGs83pnCqYg9dDrr+m3JOPQu6l9MEPEtsrOiI0Ktu/L+kV5uyBDRvB6ff
-BD6BJ2CiG86UvMpKojBeAlZBLXr1SnWzIPC+3fBzkVSo1MiRs3nTNRfeblkRxC3e
-LWtl96obA1GOgpifrh6ZB2RfvrcCgYEA5gFL4+oDUDcRtc1Pw+AFwPTey+3rkVU+
-FHvRGeU+m6dtxXF+BYFpDs/ONfmHzsdBSwkYxta/x8rKP5uyjl9p0QSdhysrJibO
-sWsoux35QxEZiyplCV2+zMK/79EhS2CuiudAidF6NxK+/g9EwXRlGDDlnFDB2epe
-kyL97K4zCtkCgYEA68Bgbsq/xzD5XFG2xqr9wN6a97gQ+W5F8QQHW74vEZJLsdYH
-Xa7rNBE8gFRiUd5zU4EL+yotPz0VWH5bilWZEJFirvQMFKRp9PRnyZzZEwLpeh+Q
-WSc8qwZudn3dgoTmqMSfNdjODed+jvEgrFkoz/8BGcVGpdcfw8IWxIUzXZcCgYAY
-/OsRx8q0XEdASR3xWdVGMVRDM4X0NB6aexkshwtWPcpfOQVH89dGFK2Cj6mBfYRK
-cqKOd6Y+Pnnajz/G1/bXDnlOxhHaAz1RaSLzsT3zW1g7FlADxHuGI2JW25GSbt6H
-mLgaQPfWI+M8FsyRd+PDzQwk/2EQG7ZKpfKQVByXgQKBgQDkKciB6Wb2hLNTKzK8
-Kr42U70H++QT8AqZX2F79PjgYcRFZqGXLuq/hEuiOhXfl8DFur3fC5JN8AeLC5/j
-bsrBsljYfVvtLQzilugs1oEe94LTrYjR2oQt0W24bqpGQHuv1ILuUBuodERkxSFL
-/cMkj3wSfC341hFaJEuG1+PcxA==
------END PRIVATE KEY-----
-KEY;
-
-        $customCertificate = <<<CERTIFICATE
------BEGIN CERTIFICATE-----
-MIIDmTCCAoGgAwIBAgIULyaeNqp0tOut/wvuxNyKmUxOGYEwDQYJKoZIhvcNAQEL
-BQAwXDELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
-CgwTRGVmYXVsdCBDb21wYW55IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29t
-MB4XDTIxMDYxNDIzMzU0MVoXDTIyMDYxNDIzMzU0MVowXDELMAkGA1UEBhMCWFgx
-FTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55
-IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEA2X6AlJM5GSws6DhU7ZV1PTmKjRcdOifxjigsAwsn5GOU
-WNcegVa1aU6n/yWlONg2ZgoyIhLoAYOG7nrvf8NtaayFoEShHvJo68PN/t0EiMkK
-7Pu/K6sA6bVHy/iMoWJZ+kgY6j0OevWNMMegPPejwzGDx4J1rXJRsLMQzSidnlrB
-/guFJC1HlTOASCxCdNGFI2sqMC/9LH5UycmOfHPX1Vdu2hgSeM563mJAaIz0NH81
-WdxyX2A/g4GFFJLszf1qITi0zU8b87f4thjcT/LWc4tBP7eCrRk7CFZkTimgl55q
-M0Mr9FREuUzWS9Z8S71bj3GvQyl8FbLdqL+XMxDPHwIDAQABo1MwUTAdBgNVHQ4E
-FgQUbAfyBm0wpM7FqUb1yqeaF4voY/gwHwYDVR0jBBgwFoAUbAfyBm0wpM7FqUb1
-yqeaF4voY/gwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAO2Dd
-k/seFjp83caYE/NVdDy5B7l5JeVtruaUdlGbb0xtVhiIdoY43ukhHFw8zuWMW9RX
-SUbrzwacfKLDBikcefk9go6cMimqYIRF8Hntph1gjjqB0papUm2WVYbsBRv2okys
-ej0dGSeUEsWjKRTSMkJsbbiEv6oveeSki069zl+tln0UhbHedkIY3rJsFIyoddSu
-g96r5HPHksnObm1JCym0xd09+msliDkBmq87mxok9m5aEqWX4XvdGfYERV/eD5vC
-KcW4DoM1KZd8E6tlniglc1jC0pzKfho7Uoe6UtObgHZGNwRYwYy+BHvHYY46ctSI
-NdZ7G/lUyrBFhsRrhw==
------END CERTIFICATE-----
-CERTIFICATE;
+        $customSsl = $this->getCustomSsl();
 
         $mock->expects($this->once())
             ->method('post')
@@ -89,8 +35,8 @@ CERTIFICATE;
                             'min_tls_version' => '1.2',
                         ],
                         'bundle_method' => 'optimal',
-                        'custom_key' => $customKey,
-                        'custom_certificate' => $customCertificate,
+                        'custom_key' => $customSsl['key'],
+                        'custom_certificate' => $customSsl['certificate'],
                         'wildcard' => true,
                     ],
                 ])
@@ -112,10 +58,7 @@ CERTIFICATE;
             'origin.example.com',
             true,
             'optimal',
-            [
-                'key' => $customKey,
-                'certificate' => $customCertificate,
-            ]
+            $customSsl
         );
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
@@ -230,5 +173,69 @@ CERTIFICATE;
 
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $result->id);
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->id);
+    }
+
+    private function getCustomSsl(): array
+    {
+        $customKey = <<<KEY
+-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDZfoCUkzkZLCzo
+OFTtlXU9OYqNFx06J/GOKCwDCyfkY5RY1x6BVrVpTqf/JaU42DZmCjIiEugBg4bu
+eu9/w21prIWgRKEe8mjrw83+3QSIyQrs+78rqwDptUfL+IyhYln6SBjqPQ569Y0w
+x6A896PDMYPHgnWtclGwsxDNKJ2eWsH+C4UkLUeVM4BILEJ00YUjayowL/0sflTJ
+yY58c9fVV27aGBJ4znreYkBojPQ0fzVZ3HJfYD+DgYUUkuzN/WohOLTNTxvzt/i2
+GNxP8tZzi0E/t4KtGTsIVmROKaCXnmozQyv0VES5TNZL1nxLvVuPca9DKXwVst2o
+v5czEM8fAgMBAAECggEBANgG/aIVpWYqaaRyp3CgviWE7Oh9J+um1xgzMJwJTaNd
+gXDIoyUmweQKW3Vjp/uRTl8GC4uqqcUvJivj8dU+gIOw970bzcmWT7616vsV/rX6
+sp524wh1vt9jzx97DfwSW3rsd8rZwHNDSO1FqxRDiOaNXO4i183iud8/zRVqHTy1
+5girngsGl7ebTt3LDHDQQ86kND2nVr8xZuFaqs8Td41AsF6DGbB709wMUqoM/obO
+iUtXCZ5Rrm2a78OUi0cqWsuxdhJjtOW0PBvrPTlSq+1EuQWAWV8HN1JI58YnLcLy
+SKZpsu5wxWdKMgX0NCkfLjDZCAPlBaZLPPp986GHavECgYEA8hM6tIfGBnXuxBvI
+y2lJG3sHGs83pnCqYg9dDrr+m3JOPQu6l9MEPEtsrOiI0Ktu/L+kV5uyBDRvB6ff
+BD6BJ2CiG86UvMpKojBeAlZBLXr1SnWzIPC+3fBzkVSo1MiRs3nTNRfeblkRxC3e
+LWtl96obA1GOgpifrh6ZB2RfvrcCgYEA5gFL4+oDUDcRtc1Pw+AFwPTey+3rkVU+
+FHvRGeU+m6dtxXF+BYFpDs/ONfmHzsdBSwkYxta/x8rKP5uyjl9p0QSdhysrJibO
+sWsoux35QxEZiyplCV2+zMK/79EhS2CuiudAidF6NxK+/g9EwXRlGDDlnFDB2epe
+kyL97K4zCtkCgYEA68Bgbsq/xzD5XFG2xqr9wN6a97gQ+W5F8QQHW74vEZJLsdYH
+Xa7rNBE8gFRiUd5zU4EL+yotPz0VWH5bilWZEJFirvQMFKRp9PRnyZzZEwLpeh+Q
+WSc8qwZudn3dgoTmqMSfNdjODed+jvEgrFkoz/8BGcVGpdcfw8IWxIUzXZcCgYAY
+/OsRx8q0XEdASR3xWdVGMVRDM4X0NB6aexkshwtWPcpfOQVH89dGFK2Cj6mBfYRK
+cqKOd6Y+Pnnajz/G1/bXDnlOxhHaAz1RaSLzsT3zW1g7FlADxHuGI2JW25GSbt6H
+mLgaQPfWI+M8FsyRd+PDzQwk/2EQG7ZKpfKQVByXgQKBgQDkKciB6Wb2hLNTKzK8
+Kr42U70H++QT8AqZX2F79PjgYcRFZqGXLuq/hEuiOhXfl8DFur3fC5JN8AeLC5/j
+bsrBsljYfVvtLQzilugs1oEe94LTrYjR2oQt0W24bqpGQHuv1ILuUBuodERkxSFL
+/cMkj3wSfC341hFaJEuG1+PcxA==
+-----END PRIVATE KEY-----
+KEY;
+
+        $customCertificate = <<<CERTIFICATE
+-----BEGIN CERTIFICATE-----
+MIIDmTCCAoGgAwIBAgIULyaeNqp0tOut/wvuxNyKmUxOGYEwDQYJKoZIhvcNAQEL
+BQAwXDELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
+CgwTRGVmYXVsdCBDb21wYW55IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29t
+MB4XDTIxMDYxNDIzMzU0MVoXDTIyMDYxNDIzMzU0MVowXDELMAkGA1UEBhMCWFgx
+FTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55
+IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEA2X6AlJM5GSws6DhU7ZV1PTmKjRcdOifxjigsAwsn5GOU
+WNcegVa1aU6n/yWlONg2ZgoyIhLoAYOG7nrvf8NtaayFoEShHvJo68PN/t0EiMkK
+7Pu/K6sA6bVHy/iMoWJZ+kgY6j0OevWNMMegPPejwzGDx4J1rXJRsLMQzSidnlrB
+/guFJC1HlTOASCxCdNGFI2sqMC/9LH5UycmOfHPX1Vdu2hgSeM563mJAaIz0NH81
+WdxyX2A/g4GFFJLszf1qITi0zU8b87f4thjcT/LWc4tBP7eCrRk7CFZkTimgl55q
+M0Mr9FREuUzWS9Z8S71bj3GvQyl8FbLdqL+XMxDPHwIDAQABo1MwUTAdBgNVHQ4E
+FgQUbAfyBm0wpM7FqUb1yqeaF4voY/gwHwYDVR0jBBgwFoAUbAfyBm0wpM7FqUb1
+yqeaF4voY/gwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAO2Dd
+k/seFjp83caYE/NVdDy5B7l5JeVtruaUdlGbb0xtVhiIdoY43ukhHFw8zuWMW9RX
+SUbrzwacfKLDBikcefk9go6cMimqYIRF8Hntph1gjjqB0papUm2WVYbsBRv2okys
+ej0dGSeUEsWjKRTSMkJsbbiEv6oveeSki069zl+tln0UhbHedkIY3rJsFIyoddSu
+g96r5HPHksnObm1JCym0xd09+msliDkBmq87mxok9m5aEqWX4XvdGfYERV/eD5vC
+KcW4DoM1KZd8E6tlniglc1jC0pzKfho7Uoe6UtObgHZGNwRYwYy+BHvHYY46ctSI
+NdZ7G/lUyrBFhsRrhw==
+-----END CERTIFICATE-----
+CERTIFICATE;
+
+        return [
+            'key' => $customKey,
+            'certificate' => $customCertificate,
+        ];
     }
 }

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -17,6 +17,61 @@ class CustomHostnamesTest extends TestCase
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
 
+        $customKey = <<<KEY
+-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDZfoCUkzkZLCzo
+OFTtlXU9OYqNFx06J/GOKCwDCyfkY5RY1x6BVrVpTqf/JaU42DZmCjIiEugBg4bu
+eu9/w21prIWgRKEe8mjrw83+3QSIyQrs+78rqwDptUfL+IyhYln6SBjqPQ569Y0w
+x6A896PDMYPHgnWtclGwsxDNKJ2eWsH+C4UkLUeVM4BILEJ00YUjayowL/0sflTJ
+yY58c9fVV27aGBJ4znreYkBojPQ0fzVZ3HJfYD+DgYUUkuzN/WohOLTNTxvzt/i2
+GNxP8tZzi0E/t4KtGTsIVmROKaCXnmozQyv0VES5TNZL1nxLvVuPca9DKXwVst2o
+v5czEM8fAgMBAAECggEBANgG/aIVpWYqaaRyp3CgviWE7Oh9J+um1xgzMJwJTaNd
+gXDIoyUmweQKW3Vjp/uRTl8GC4uqqcUvJivj8dU+gIOw970bzcmWT7616vsV/rX6
+sp524wh1vt9jzx97DfwSW3rsd8rZwHNDSO1FqxRDiOaNXO4i183iud8/zRVqHTy1
+5girngsGl7ebTt3LDHDQQ86kND2nVr8xZuFaqs8Td41AsF6DGbB709wMUqoM/obO
+iUtXCZ5Rrm2a78OUi0cqWsuxdhJjtOW0PBvrPTlSq+1EuQWAWV8HN1JI58YnLcLy
+SKZpsu5wxWdKMgX0NCkfLjDZCAPlBaZLPPp986GHavECgYEA8hM6tIfGBnXuxBvI
+y2lJG3sHGs83pnCqYg9dDrr+m3JOPQu6l9MEPEtsrOiI0Ktu/L+kV5uyBDRvB6ff
+BD6BJ2CiG86UvMpKojBeAlZBLXr1SnWzIPC+3fBzkVSo1MiRs3nTNRfeblkRxC3e
+LWtl96obA1GOgpifrh6ZB2RfvrcCgYEA5gFL4+oDUDcRtc1Pw+AFwPTey+3rkVU+
+FHvRGeU+m6dtxXF+BYFpDs/ONfmHzsdBSwkYxta/x8rKP5uyjl9p0QSdhysrJibO
+sWsoux35QxEZiyplCV2+zMK/79EhS2CuiudAidF6NxK+/g9EwXRlGDDlnFDB2epe
+kyL97K4zCtkCgYEA68Bgbsq/xzD5XFG2xqr9wN6a97gQ+W5F8QQHW74vEZJLsdYH
+Xa7rNBE8gFRiUd5zU4EL+yotPz0VWH5bilWZEJFirvQMFKRp9PRnyZzZEwLpeh+Q
+WSc8qwZudn3dgoTmqMSfNdjODed+jvEgrFkoz/8BGcVGpdcfw8IWxIUzXZcCgYAY
+/OsRx8q0XEdASR3xWdVGMVRDM4X0NB6aexkshwtWPcpfOQVH89dGFK2Cj6mBfYRK
+cqKOd6Y+Pnnajz/G1/bXDnlOxhHaAz1RaSLzsT3zW1g7FlADxHuGI2JW25GSbt6H
+mLgaQPfWI+M8FsyRd+PDzQwk/2EQG7ZKpfKQVByXgQKBgQDkKciB6Wb2hLNTKzK8
+Kr42U70H++QT8AqZX2F79PjgYcRFZqGXLuq/hEuiOhXfl8DFur3fC5JN8AeLC5/j
+bsrBsljYfVvtLQzilugs1oEe94LTrYjR2oQt0W24bqpGQHuv1ILuUBuodERkxSFL
+/cMkj3wSfC341hFaJEuG1+PcxA==
+-----END PRIVATE KEY-----
+KEY;
+    $customCertificate = <<<CERTIFICATE
+-----BEGIN CERTIFICATE-----
+MIIDmTCCAoGgAwIBAgIULyaeNqp0tOut/wvuxNyKmUxOGYEwDQYJKoZIhvcNAQEL
+BQAwXDELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
+CgwTRGVmYXVsdCBDb21wYW55IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29t
+MB4XDTIxMDYxNDIzMzU0MVoXDTIyMDYxNDIzMzU0MVowXDELMAkGA1UEBhMCWFgx
+FTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55
+IEx0ZDEYMBYGA1UEAwwPYXBwLmV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEA2X6AlJM5GSws6DhU7ZV1PTmKjRcdOifxjigsAwsn5GOU
+WNcegVa1aU6n/yWlONg2ZgoyIhLoAYOG7nrvf8NtaayFoEShHvJo68PN/t0EiMkK
+7Pu/K6sA6bVHy/iMoWJZ+kgY6j0OevWNMMegPPejwzGDx4J1rXJRsLMQzSidnlrB
+/guFJC1HlTOASCxCdNGFI2sqMC/9LH5UycmOfHPX1Vdu2hgSeM563mJAaIz0NH81
+WdxyX2A/g4GFFJLszf1qITi0zU8b87f4thjcT/LWc4tBP7eCrRk7CFZkTimgl55q
+M0Mr9FREuUzWS9Z8S71bj3GvQyl8FbLdqL+XMxDPHwIDAQABo1MwUTAdBgNVHQ4E
+FgQUbAfyBm0wpM7FqUb1yqeaF4voY/gwHwYDVR0jBBgwFoAUbAfyBm0wpM7FqUb1
+yqeaF4voY/gwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAO2Dd
+k/seFjp83caYE/NVdDy5B7l5JeVtruaUdlGbb0xtVhiIdoY43ukhHFw8zuWMW9RX
+SUbrzwacfKLDBikcefk9go6cMimqYIRF8Hntph1gjjqB0papUm2WVYbsBRv2okys
+ej0dGSeUEsWjKRTSMkJsbbiEv6oveeSki069zl+tln0UhbHedkIY3rJsFIyoddSu
+g96r5HPHksnObm1JCym0xd09+msliDkBmq87mxok9m5aEqWX4XvdGfYERV/eD5vC
+KcW4DoM1KZd8E6tlniglc1jC0pzKfho7Uoe6UtObgHZGNwRYwYy+BHvHYY46ctSI
+NdZ7G/lUyrBFhsRrhw==
+-----END CERTIFICATE-----
+CERTIFICATE;
+
         $mock->expects($this->once())
             ->method('post')
             ->with(
@@ -33,6 +88,9 @@ class CustomHostnamesTest extends TestCase
                             'min_tls_version' => '1.2'
                         ]
                     ],
+                    'bundle_method' => 'optimal',
+                    'custom_key' => $customKey,
+                    'custom_certificate' => $customCertificate,
                     'wildcard' => true,
                 ])
             );
@@ -43,7 +101,7 @@ class CustomHostnamesTest extends TestCase
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
-        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com', true);
+        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com', true, 'optimal', $customKey, $customCertificate);
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -14,10 +14,10 @@ class CustomHostnamesTest extends TestCase
     {
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/createCustomHostname.json');
 
-        $customSsl = $this->getCustomSsl();
-
         $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
         $mock->method('post')->willReturn($response);
+
+        $customSsl = $this->getCustomSsl();
 
         $mock->expects($this->once())
             ->method('post')

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -101,7 +101,18 @@ CERTIFICATE;
             'http3' => 'on',
             'min_tls_version' => '1.2'
         ];
-        $hostname->addHostname('023e105f4ecef8ad9ca31a8372d0c353', 'app.example.com', 'http', 'dv', $sslSettings, 'origin.example.com', true, 'optimal', $customKey, $customCertificate);
+        $hostname->addHostname(
+            '023e105f4ecef8ad9ca31a8372d0c353',
+            'app.example.com',
+            'http',
+            'dv',
+            $sslSettings,
+            'origin.example.com',
+            true,
+            'optimal',
+            $customKey,
+            $customCertificate
+        );
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $hostname->getBody()->result->id);
     }
 


### PR DESCRIPTION
As mentioned in #177, there are some missing properties from custom hostname creation (shown at https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname). This PR attempts to add these in.

Closes #177