### PR TITLE
Add Custom Hostname Fallback Origin Retrieval

### DIFF
--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -169,4 +169,16 @@ class CustomHostnames implements API
         $this->body = json_decode($zone->getBody());
         return $this->body;
     }
+
+    /**
+     * @param string $zoneID
+     * @return \stdClass
+     */
+    public function getFallbackOrigin(string $zoneID): \stdClass
+    {
+        $zone = $this->adapter->get('zones/'.$zoneID.'/custom_hostnames/fallback_origin');
+        $this->body = json_decode($zone->getBody());
+
+        return $this->body->result;
+    }
 }

--- a/tests/Endpoints/CustomHostnamesTest.php
+++ b/tests/Endpoints/CustomHostnamesTest.php
@@ -158,4 +158,24 @@ class CustomHostnamesTest extends TestCase
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $result->id);
         $this->assertEquals('0d89c70d-ad9f-4843-b99f-6cc0252067e9', $zones->getBody()->id);
     }
+
+    public function testGetHostnameFallbackOrigin()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getCustomHostnameFallbackOrigin.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('get')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('zones/023e105f4ecef8ad9ca31a8372d0c353/custom_hostnames/fallback_origin')
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\CustomHostnames($mock);
+        $result = $zones->getFallbackOrigin('023e105f4ecef8ad9ca31a8372d0c353');
+
+        $this->assertObjectHasAttribute('origin', $result);
+        $this->assertObjectHasAttribute('status', $result);
+    }
 }

--- a/tests/Fixtures/Endpoints/getCustomHostnameFallbackOrigin.json
+++ b/tests/Fixtures/Endpoints/getCustomHostnameFallbackOrigin.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [
+    {}
+  ],
+  "messages": [
+    {}
+  ],
+  "result": {
+    "origin": "fallback.example.com",
+    "status": "pending_deployment",
+    "errors": [
+      "DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record"
+    ],
+    "created_at": "2019-10-28T18:11:23.37411Z",
+    "updated_at": "2020-03-16T18:11:23.531995Z"
+  }
+}


### PR DESCRIPTION
This will add support to get SSL for SaaS fallback origins via the SDK.

Closes #181.