### PR TITLE
Add Account Creation

### DIFF
--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -28,7 +28,7 @@ class Accounts implements API
             'type' => $type,
         ];
 
-        $account    = $this->adapter->post('accounts', $options);
+        $account = $this->adapter->post('accounts', $options);
         $this->body = json_decode($account->getBody());
 
         return $this->body->result;

--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -21,7 +21,8 @@ class Accounts implements API
         $this->adapter = $adapter;
     }
 
-    public function addAccount(string $name, string $type = 'standard'): \stdClass {
+    public function addAccount(string $name, string $type = 'standard'): \stdClass
+    {
         $options = [
             'name' => $name,
             'type' => $type,

--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -21,6 +21,18 @@ class Accounts implements API
         $this->adapter = $adapter;
     }
 
+    public function addAccount(string $name, string $type = 'standard'): \stdClass {
+        $options = [
+            'name' => $name,
+            'type' => $type,
+        ];
+
+        $account = $this->adapter->post('accounts', $options);
+        $this->body = json_decode($account->getBody());
+
+        return $this->body->result;
+    }
+
     public function listAccounts(
         int $page = 1,
         int $perPage = 20,

--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -28,7 +28,7 @@ class Accounts implements API
             'type' => $type,
         ];
 
-        $account = $this->adapter->post('accounts', $options);
+        $account    = $this->adapter->post('accounts', $options);
         $this->body = json_decode($account->getBody());
 
         return $this->body->result;

--- a/tests/Endpoints/AccountsTest.php
+++ b/tests/Endpoints/AccountsTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Cloudflare\API\Endpoints\Accounts;
+
 /**
  * User: kanasite
  * Date: 01/28/2019
@@ -24,7 +27,7 @@ class AccountsTest extends TestCase
                 ])
             );
 
-        $accounts = new \Cloudflare\API\Endpoints\Accounts($mock);
+        $accounts = new Accounts($mock);
         $result = $accounts->listAccounts(1, 20, 'desc');
 
         $this->assertObjectHasAttribute('result', $result);
@@ -33,5 +36,51 @@ class AccountsTest extends TestCase
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $result->result[0]->id);
         $this->assertEquals(1, $result->result_info->page);
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $accounts->getBody()->result[0]->id);
+    }
+
+    public function testAddAccountWithDefaultType()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createStandardAccount.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts'),
+                $this->equalTo([
+                    'name' => 'Foo Bar',
+                    'type' => 'standard',
+                ])
+            );
+
+        $accounts = new Accounts($mock);
+
+        $accounts->addAccount('Foo Bar');
+        $this->assertEquals('2bab6ace8c72ed3f09b9eca6db1396bb', $accounts->getBody()->result->id);
+    }
+
+    public function testAddAccountWithCustomType()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/createEnterpriseAccount.json');
+
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+        $mock->method('post')->willReturn($response);
+
+        $mock->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts'),
+                $this->equalTo([
+                    'name' => 'Foo Bar',
+                    'type' => 'enterprise',
+                ])
+            );
+
+        $accounts = new Accounts($mock);
+
+        $accounts->addAccount('Foo Bar', 'enterprise');
+        $this->assertEquals('2bab6ace8c72ed3f09b9eca6db1396bb', $accounts->getBody()->result->id);
     }
 }

--- a/tests/Fixtures/Endpoints/createEnterpriseAccount.json
+++ b/tests/Fixtures/Endpoints/createEnterpriseAccount.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "id": "2bab6ace8c72ed3f09b9eca6db1396bb",
+    "name": "Foo Bar",
+    "type": "enterprise",
+    "settings": {
+      "enforce_twofactor": false
+    }
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/Fixtures/Endpoints/createStandardAccount.json
+++ b/tests/Fixtures/Endpoints/createStandardAccount.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "id": "2bab6ace8c72ed3f09b9eca6db1396bb",
+    "name": "Foo Bar",
+    "type": "standard",
+    "settings": {
+      "enforce_twofactor": false
+    }
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}


### PR DESCRIPTION
This is used on the tenant API (https://developers.cloudflare.com/tenant/tutorial/provisioning-resources#creating-an-account) but is currently undocumented on the main API documentation

Closes #186