### PR TITLE
Fix for post-ing form data.

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -80,14 +80,31 @@ class Guzzle implements Adapter
         }
 
         try {
-            $response = $this->client->$method($uri, [
-                'headers' => $headers,
-                ($method === 'get' ? 'query' : 'json') => $data,
-            ]);
+            $methodData = $this->getMethodData($method, $data);
+            $response = $this->client->$method($uri, ['headers' => $headers] + $methodData);
         } catch (RequestException $err) {
             throw ResponseException::fromRequestException($err);
         }
 
         return $response;
+    }
+
+    /**
+     * Gets the data for the request as per the method.
+     * @param string $method
+     * @param array $data
+     * @return array|array[]
+     */
+    public function getMethodData(string $method, array $data): array
+    {
+        if ($method === 'get') {
+            return ['query' => $data];
+        }
+
+        if (array_key_exists('multipart', $data)) {
+            return $data;
+        }
+
+        return ['json' => $data];
     }
 }


### PR DESCRIPTION
When using the https://api.cloudflare.com/#dns-records-for-a-zone-import-dns-records endpoint I am getting;  
Failed to parse form data. Make sure the Content-Type is multipart/form-data.  

It appear to be the force key fo json being applied to all non-get requests is causing the issue.

Issue: https://github.com/cloudflare/cloudflare-php/issues/226