### PR TITLE
Update LoadBalancer.php

### DIFF
--- a/src/Configurations/LoadBalancer.php
+++ b/src/Configurations/LoadBalancer.php
@@ -40,12 +40,12 @@ class LoadBalancer implements Configurations
 
     public function setFallbackPool(string $fallbackPool)
     {
-        $this->configs['fallback_pools'] = $fallbackPool;
+        $this->configs['fallback_pool'] = $fallbackPool;
     }
 
     public function getFallbackPool():string
     {
-        return $this->configs['fallback_pools'] ?? '';
+        return $this->configs['fallback_pool'] ?? '';
     }
 
     public function setSteeringPolicy(string $steeringPolicy = '')


### PR DESCRIPTION
in the api "fallback_pools" is actually "fallback_pool", so this minor change will fix this typo