### PR TITLE
Mark the package as abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "cloudflare/sdk",
   "description": "PHP binding for v4 of the Cloudflare Client API.",
   "type": "library",
+  "abandoned": true,
   "require": {
     "guzzlehttp/guzzle": "^7.0.1",
     "php": ">=7.2.5",


### PR DESCRIPTION
This package is no longer supported by Cloudflare, as per @ramsey's comment: "I spoke to someone at Cloudflare, and they said they don't intend to update this SDK. They advised against using it and indicated that their current view of SDKs is that they don't provide a level of value that is equal to the amount of effort it takes to maintain them. They are focusing on making the APIs as easy as possible to use directly, and their recommendation is to use the APIs directly." (https://github.com/cloudflare/cloudflare-php/issues/235#issuecomment-1423010678)