### PR TITLE
Fix addHostname "Unable to decode the JSON request body. Please check your input and try again." on Free Tier

### DIFF
--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -42,7 +42,7 @@ class CustomHostnames implements API
         string $hostname,
         string $sslMethod = 'http',
         string $sslType = 'dv',
-        array $sslSettings = [],
+        array|null $sslSettings = null,
         string $customOriginServer = '',
         bool $wildcard = false,
         string $bundleMethod = '',


### PR DESCRIPTION
Fix addHostname "Unable to decode the JSON request body. Please check your input and try again." on Free Tier