### PR TITLE
make cache purge environment aware

### DIFF
--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Created by PhpStorm.
  * User: junade
@@ -217,8 +218,15 @@ class Zones implements API
      * @param string $zoneID
      * @return bool
      */
-    public function cachePurgeEverything(string $zoneID): bool
+    public function cachePurgeEverything(string $zoneID, bool $includeEnvironments = false): bool
     {
+        if ($includeEnvironments) {
+            $env = $this->adapter->get("zones/$zoneID/environments");
+            $envs = json_decode($env->getBody(), true);
+            foreach ($envs["result"]["environments"] as $env) {
+                $this->adapter->post("zones/$zoneID/environments/{$env["ref"]}/purge_cache", ['purge_everything' => true]);
+            }
+        }
         $user = $this->adapter->post('zones/' . $zoneID . '/purge_cache', ['purge_everything' => true]);
 
         $this->body = json_decode($user->getBody());
@@ -230,7 +238,7 @@ class Zones implements API
         return false;
     }
 
-    public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null): bool
+    public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null, bool $includeEnvironments = false): bool
     {
         if ($files === null && $tags === null && $hosts === null) {
             throw new EndpointException('No files, tags or hosts to purge.');
@@ -247,6 +255,14 @@ class Zones implements API
 
         if (!is_null($hosts)) {
             $options['hosts'] = $hosts;
+        }
+
+        if ($includeEnvironments) {
+            $env = $this->adapter->get("zones/$zoneID/environments");
+            $envs = json_decode($env->getBody(), true);
+            foreach ($envs["result"]["environments"] as $env) {
+                $this->adapter->post("zones/$zoneID/environments/{$env["ref"]}/purge_cache", $options);
+            }
         }
 
         $user = $this->adapter->post('zones/' . $zoneID . '/purge_cache', $options);

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -240,9 +240,9 @@ class Zones implements API
         return false;
     }
 
-    /*
-     *  @SuppressWarnings(PHPMD)
-     **/
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
     public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null, bool $includeEnvironments = false): bool
     {
         if ($files === null && $tags === null && $hosts === null) {

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -217,6 +217,8 @@ class Zones implements API
      * Purge Everything
      * @param string $zoneID
      * @return bool
+     *
+     * @SuppressWarnings(PHPMD)
      */
     public function cachePurgeEverything(string $zoneID, bool $includeEnvironments = false): bool
     {
@@ -238,6 +240,9 @@ class Zones implements API
         return false;
     }
 
+    /*
+     *  @SuppressWarnings(PHPMD)
+     **/
     public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null, bool $includeEnvironments = false): bool
     {
         if ($files === null && $tags === null && $hosts === null) {

--- a/tests/Endpoints/ZoneCacheTest.php
+++ b/tests/Endpoints/ZoneCacheTest.php
@@ -147,7 +147,7 @@ class ZoneCacheTest extends TestCase
             ->method('get')
             ->willReturn($envResp)
             ->with(
-                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments'),
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments')
             );
 
         $mock->expects($this->exactly(4))

--- a/tests/Endpoints/ZoneCacheTest.php
+++ b/tests/Endpoints/ZoneCacheTest.php
@@ -87,7 +87,7 @@ class ZoneCacheTest extends TestCase
             ->method('get')
             ->willReturn($envResp)
             ->with(
-                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments'),
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments')
             );
 
         $mock->expects($this->exactly(4))

--- a/tests/Endpoints/ZoneCacheTest.php
+++ b/tests/Endpoints/ZoneCacheTest.php
@@ -61,9 +61,10 @@ class ZoneCacheTest extends TestCase
             ->method('post')
             ->with(
                 $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
-                $this->equalTo(['files' => [
-                    'https://example.com/file.jpg',
-                ]
+                $this->equalTo([
+                    'files' => [
+                        'https://example.com/file.jpg',
+                    ]
                 ])
             );
 
@@ -71,6 +72,108 @@ class ZoneCacheTest extends TestCase
         $result = $zones->cachePurge('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', [
             'https://example.com/file.jpg',
         ]);
+
+        $this->assertTrue($result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
+    }
+
+    public function testCachePurgeIncludingEnvironments()
+    {
+        $envResp = $this->getPsr7JsonResponseForFixture('Endpoints/getEnvironments.json');
+        $cacheResp = $this->getPsr7JsonResponseForFixture('Endpoints/cachePurge.json');
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+
+        $mock->expects($this->once())
+            ->method('get')
+            ->willReturn($envResp)
+            ->with(
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments'),
+            );
+
+        $mock->expects($this->exactly(4))
+            ->method('post')
+            ->willReturn($cacheResp)
+            ->withConsecutive(
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/first/purge_cache'),
+                    $this->equalTo([
+                        'files' => [
+                            'https://example.com/file.jpg',
+                        ]
+                    ])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/second/purge_cache'),
+                    $this->equalTo([
+                        'files' => [
+                            'https://example.com/file.jpg',
+                        ]
+                    ])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/third/purge_cache'),
+                    $this->equalTo([
+                        'files' => [
+                            'https://example.com/file.jpg',
+                        ]
+                    ])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
+                    $this->equalTo([
+                        'files' => [
+                            'https://example.com/file.jpg',
+                        ]
+                    ])
+                ]
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\Zones($mock);
+        $result = $zones->cachePurge('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', [
+            'https://example.com/file.jpg',
+        ], null, null, true);
+
+        $this->assertTrue($result);
+        $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);
+    }
+
+    public function testCachePurgeEverythingIncludingEnvironments()
+    {
+        $envResp = $this->getPsr7JsonResponseForFixture('Endpoints/getEnvironments.json');
+        $cacheResp = $this->getPsr7JsonResponseForFixture('Endpoints/cachePurgeEverything.json');
+        $mock = $this->getMockBuilder(\Cloudflare\API\Adapter\Adapter::class)->getMock();
+
+        $mock->expects($this->once())
+            ->method('get')
+            ->willReturn($envResp)
+            ->with(
+                $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments'),
+            );
+
+        $mock->expects($this->exactly(4))
+            ->method('post')
+            ->willReturn($cacheResp)
+            ->withConsecutive(
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/first/purge_cache'),
+                    $this->equalTo(['purge_everything' => true])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/second/purge_cache'),
+                    $this->equalTo(['purge_everything' => true])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/environments/third/purge_cache'),
+                    $this->equalTo(['purge_everything' => true])
+                ],
+                [
+                    $this->equalTo('zones/c2547eb745079dac9320b638f5e225cf483cc5cfdda41/purge_cache'),
+                    $this->equalTo(['purge_everything' => true])
+                ]
+            );
+
+        $zones = new \Cloudflare\API\Endpoints\Zones($mock);
+        $result = $zones->cachePurgeEverything('c2547eb745079dac9320b638f5e225cf483cc5cfdda41', true);
 
         $this->assertTrue($result);
         $this->assertEquals('023e105f4ecef8ad9ca31a8372d0c353', $zones->getBody()->result->id);

--- a/tests/Fixtures/Endpoints/getEnvironments.json
+++ b/tests/Fixtures/Endpoints/getEnvironments.json
@@ -1,0 +1,40 @@
+{
+  "result": {
+    "environments": [
+      {
+        "name": "Production",
+        "ref": "first",
+        "version": 0,
+        "expression": "expression_1",
+        "locked_on_deployment": false,
+        "position": {
+          "before": "second"
+        }
+      },
+      {
+        "name": "Staging",
+        "ref": "second",
+        "version": 0,
+        "expression": "expression_2",
+        "locked_on_deployment": false,
+        "position": {
+          "before": "third",
+          "after": "first"
+        }
+      },
+      {
+        "name": "Development",
+        "ref": "third",
+        "version": 0,
+        "expression": "expression_3",
+        "locked_on_deployment": false,
+        "position": {
+          "after": "second"
+        }
+      }
+    ]
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}


### PR DESCRIPTION
This PR aims to make the zone cache functions environment aware. As of right now, the plan is to allow users to include zone versioning environments when they call their cache purge functions.
```
php vendor/bin/phpunit --configuration phpunit.xml
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

...............................................................  63 / 158 ( 39%)
............................................................... 126 / 158 ( 79%)
................................                                158 / 158 (100%)

Time: 4.8 seconds, Memory: 8.00MB

OK (158 tests, 983 assertions)

```