### PR TITLE
Explicitly declare nullable types to fix deprecation in PHP 8.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.php_cs
+++ b/.php_cs
@@ -10,6 +10,7 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder)
 ;

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -14,7 +14,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function __construct(Auth $auth, string $baseURI = null)
+    public function __construct(Auth $auth, ?string $baseURI = null)
     {
         if ($baseURI === null) {
             $baseURI = 'https://api.cloudflare.com/client/v4/';

--- a/src/Endpoints/AccessRules.php
+++ b/src/Endpoints/AccessRules.php
@@ -90,7 +90,7 @@ class AccessRules implements API
         string $zoneID,
         string $mode,
         Configurations $configuration,
-        string $notes = null
+        ?string $notes = null
     ): bool {
         $options = [
             'mode' => $mode,
@@ -116,7 +116,7 @@ class AccessRules implements API
         string $zoneID,
         string $ruleID,
         string $mode,
-        string $notes = null
+        ?string $notes = null
     ): bool {
         $options = [
             'mode' => $mode

--- a/src/Endpoints/CustomHostnames.php
+++ b/src/Endpoints/CustomHostnames.php
@@ -164,7 +164,7 @@ class CustomHostnames implements API
         string $sslType = '',
         array $sslSettings = [],
         string $customOriginServer = '',
-        bool $wildcard = null,
+        ?bool $wildcard = null,
         string $bundleMethod = '',
         array $customSsl = []
     ): \stdClass {

--- a/src/Endpoints/Firewall.php
+++ b/src/Endpoints/Firewall.php
@@ -34,8 +34,8 @@ class Firewall implements API
         string $zoneID,
         string $expression,
         FirewallRuleOptions $options,
-        string $description = null,
-        int $priority = null
+        ?string $description = null,
+        ?int $priority = null
     ): bool {
         $rule = array_merge([
             'filter' => [
@@ -92,8 +92,8 @@ class Firewall implements API
         string $filterID,
         string $expression,
         FirewallRuleOptions $options,
-        string $description = null,
-        int $priority = null
+        ?string $description = null,
+        ?int $priority = null
     ): \stdClass {
         $rule = array_merge([
             'id' => $ruleID,

--- a/src/Endpoints/PageRules.php
+++ b/src/Endpoints/PageRules.php
@@ -39,7 +39,7 @@ class PageRules implements API
         PageRulesTargets $target,
         PageRulesActions $actions,
         bool $active = true,
-        int $priority = null
+        ?int $priority = null
     ): bool {
         $options = [
             'targets' => $target->getArray(),
@@ -68,10 +68,10 @@ class PageRules implements API
 
     public function listPageRules(
         string $zoneID,
-        string $status = null,
-        string $order = null,
-        string $direction = null,
-        string $match = null
+        ?string $status = null,
+        ?string $order = null,
+        ?string $direction = null,
+        ?string $match = null
     ): array {
         if ($status != null && !in_array($status, ['active', 'disabled'])) {
             throw new EndpointException('Page Rules can only be listed by status of active or disabled.');
@@ -114,8 +114,8 @@ class PageRules implements API
         string $ruleID,
         PageRulesTargets $target,
         PageRulesActions $actions,
-        bool $active = null,
-        int $priority = null
+        ?bool $active = null,
+        ?int $priority = null
     ): bool {
         $options = [];
         $options['targets'] = $target->getArray();
@@ -143,10 +143,10 @@ class PageRules implements API
     public function updatePageRule(
         string $zoneID,
         string $ruleID,
-        PageRulesTargets $target = null,
-        PageRulesActions $actions = null,
-        bool $active = null,
-        int $priority = null
+        ?PageRulesTargets $target = null,
+        ?PageRulesActions $actions = null,
+        ?bool $active = null,
+        ?int $priority = null
     ): bool {
         $options = [];
 

--- a/src/Endpoints/UARules.php
+++ b/src/Endpoints/UARules.php
@@ -43,8 +43,8 @@ class UARules implements API
         string $zoneID,
         string $mode,
         Configurations $configuration,
-        string $ruleID = null,
-        string $description = null
+        ?string $ruleID = null,
+        ?string $description = null
     ): bool {
         $options = [
             'mode' => $mode,
@@ -82,7 +82,7 @@ class UARules implements API
         string $ruleID,
         string $mode,
         \Cloudflare\API\Configurations\UARules $configuration,
-        string $description = null
+        ?string $description = null
     ): bool {
         $options = [
             'mode' => $mode,

--- a/src/Endpoints/ZoneLockdown.php
+++ b/src/Endpoints/ZoneLockdown.php
@@ -42,8 +42,8 @@ class ZoneLockdown implements API
         string $zoneID,
         array $urls,
         \Cloudflare\API\Configurations\ZoneLockdown $configuration,
-        string $lockdownID = null,
-        string $description = null
+        ?string $lockdownID = null,
+        ?string $description = null
     ): bool {
         $options = [
             'urls' => $urls,
@@ -81,7 +81,7 @@ class ZoneLockdown implements API
         string $lockdownID,
         array $urls,
         \Cloudflare\API\Configurations\ZoneLockdown $configuration,
-        string $description = null
+        ?string $description = null
     ): bool {
         $options = [
             'urls' => $urls,

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -243,7 +243,7 @@ class Zones implements API
     /**
      * @SuppressWarnings(PHPMD)
      */
-    public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null, bool $includeEnvironments = false): bool
+    public function cachePurge(string $zoneID, ?array $files = null, ?array $tags = null, ?array $hosts = null, bool $includeEnvironments = false): bool
     {
         if ($files === null && $tags === null && $hosts === null) {
             throw new EndpointException('No files, tags or hosts to purge.');


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable types.

You get a deprecation warning like so:

Cloudflare\API\Endpoints\Zones::cachePurge(): Implicitly marking parameter $hosts as nullable is deprecated, the explicit nullable type must be used instead in src/Endpoints/Zones.php:246

Nullable types are available since 7.1.0. There is CI action for PHP 7.0, but the composer requires has `"php": ">=7.2.5"`