### PR TITLE
Fix psr/http-message version constraint to support PSR-7 v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "guzzlehttp/guzzle": "^7.0.1",
     "php": ">=7.2.5",
-    "psr/http-message": "~1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
the current "psr/http-message": "~1.0" constraint conflicts with Guzzle 7 implementations and forces downgrades in dependent projects.


## The Change:
Updated psr/http-message constraint:

**Before:** "psr/http-message": "~1.0"

**After:** "psr/http-message": "^1.0 || ^2.0"


## Why This Fix:

1. Root Cause: The old constraint ~1.0 means >=1.0 <2.0, which blocks PSR-7 version 2.0

2. The Conflict:

Guzzle 7 (required by cloudflare/sdk) uses "guzzlehttp/psr7": "^2.8",

reference: https://github.com/guzzle/guzzle/blob/7.10/composer.json

guzzlehttp/psr7 v2.x requires "psr/http-message": "^1.1 || ^2.0",

reference: https://github.com/guzzle/psr7/blob/2.8/composer.json

But cloudflare/sdk was blocking version 2.0


## The change allows both:

PSR-7 v1.x (for backward compatibility)

PSR-7 v2.x (for modern implementations)