### PR TITLE
Fix PHP 8.4 implicit-nullable deprecations (#277)

### DIFF
--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -14,7 +14,7 @@ class Guzzle implements Adapter
     /**
      * @inheritDoc
      */
-    public function __construct(Auth $auth, string $baseURI = null)
+    public function __construct(Auth $auth, ?string $baseURI = null)
     {
         if ($baseURI === null) {
             $baseURI = 'https://api.cloudflare.com/client/v4/';

--- a/src/Endpoints/Zones.php
+++ b/src/Endpoints/Zones.php
@@ -243,7 +243,7 @@ class Zones implements API
     /**
      * @SuppressWarnings(PHPMD)
      */
-    public function cachePurge(string $zoneID, array $files = null, array $tags = null, array $hosts = null, bool $includeEnvironments = false): bool
+    public function cachePurge(string $zoneID, ?array $files = null, ?array $tags = null, ?array $hosts = null, bool $includeEnvironments = false): bool
     {
         if ($files === null && $tags === null && $hosts === null) {
             throw new EndpointException('No files, tags or hosts to purge.');


### PR DESCRIPTION
Fixes #277.

PHP 8.4 emits `E_DEPRECATED` for parameters that default to `null` without an explicit nullable type. PHP 9.0 will turn these into fatal errors.

This PR adds the `?` prefix to four parameters:

| File | Method | Parameter |
|------|--------|-----------|
| `src/Adapter/Guzzle.php` | `__construct` | `$baseURI` |
| `src/Endpoints/Zones.php` | `cachePurge` | `$files` |
| `src/Endpoints/Zones.php` | `cachePurge` | `$tags` |
| `src/Endpoints/Zones.php` | `cachePurge` | `$hosts` |

The public method contracts are unchanged — these parameters were already accepting `null` at runtime; this just declares it explicitly so the language stops complaining.

No behavior change, no test changes required.