### PR TITLE
docs: update README and add CHANGELOG for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 2.0.0
+
+### Breaking Changes
+
+- **Minimum PHP version raised from 7.2.5 to 8.1.** PHP 7.x and 8.0 are no
+  longer supported. All of these versions are past end-of-life upstream.
+
+### Changes
+
+- Add support for `psr/http-message` v2.0 (constraint is now `^1.1 || ^2.0`).
+  This resolves dependency conflicts with libraries that require PSR-7 v2,
+  including `league/oauth2-server` and newer Drupal modules.
+  ([#275](https://github.com/cloudflare/cloudflare-php/pull/275))
+- Fix PHP 8.4 implicit-nullable deprecation warnings in `Guzzle::__construct()`
+  and `Zones::cachePurge()`.
+  ([#280](https://github.com/cloudflare/cloudflare-php/pull/280))
+- Upgrade `guzzlehttp/guzzle` constraint from `^7.0.1` to `^7.4`.
+- Upgrade `phpunit/phpunit` from `^5.7` to `^9.6 || ^10.0 || ^11.0`.
+- Upgrade `friendsofphp/php-cs-fixer` from `^2.6` to `^3.0`.
+- Remove committed `composer.lock` (correct practice for libraries).
+- Update GitHub Actions workflows: `actions/checkout` v4, `actions/cache` v4,
+  `php-actions/composer` v6, Semgrep runner to `ubuntu-latest`.
+- Fix PHP test matrix to 8.1, 8.2, 8.3, 8.4.
+- Migrate linter config from `.php_cs` to `.php-cs-fixer.php`.
+- Add PHPMD ruleset file (`phpmd.xml`).
+- Remove unused test variables in `DNSAnalyticsTest`.
+- Update README to reflect PHP 8.1+ requirement and current project status.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
-# Cloudflare SDK (v4 API Binding for PHP 7)
+# Cloudflare SDK (v4 API Binding for PHP)
 
-[![Build Status](https://travis-ci.org/cloudflare/cloudflare-php.svg?branch=master)](https://travis-ci.org/cloudflare/cloudflare-php)
+> **Note:** This is a community-maintained PHP SDK covering a subset of the
+> Cloudflare API. A comprehensive, auto-generated PHP SDK is planned for the
+> future. In the meantime, for full API coverage consider using the
+> [Cloudflare API](https://developers.cloudflare.com/api/) directly.
+
+## Requirements
+
+- PHP 8.1 or later
 
 ## Installation
 
-The recommended way to install this package is via the Packagist Dependency Manager ([cloudflare/sdk](https://packagist.org/packages/cloudflare/sdk)).
+Install via Composer ([cloudflare/sdk](https://packagist.org/packages/cloudflare/sdk)):
 
 ```
 composer require cloudflare/sdk
 ```
 
-You can get specific usage examples on the Cloudflare Knowledge Base under: [Cloudflare PHP API Binding](https://support.cloudflare.com/hc/en-us/articles/115001661191)
-
 ## Cloudflare API version 4
 
-The Cloudflare API can be found [here](https://api.cloudflare.com/).
+The Cloudflare API can be found [here](https://developers.cloudflare.com/api/).
 Each API call is provided via a similarly named function within various classes in the **Cloudflare\API\Endpoints** namespace:
 
 - [x] [DNS Records](https://www.cloudflare.com/dns/)
-- [x] [DNS Analytics](https://api.cloudflare.com/#dns-analytics-table)
+- [x] DNS Analytics
 - [x] Zones
 - [x] User Administration (partial)
 - [x] [Cloudflare IPs](https://www.cloudflare.com/ips/)
-- [x] [Page Rules](https://support.cloudflare.com/hc/en-us/articles/200168306-Is-there-a-tutorial-for-Page-Rules-)
+- [x] Page Rules
 - [x] [Web Application Firewall (WAF)](https://www.cloudflare.com/waf/)
 - [ ] Virtual DNS Management
 - [x] Custom hostnames
@@ -35,8 +40,6 @@ Each API call is provided via a similarly named function within various classes 
 - [x] Crypto
 - [x] Load Balancers
 - [x] Firewall Settings
-
-Note that this repository is currently under development, additional classes and endpoints being actively added.
 
 ## Getting Started
 


### PR DESCRIPTION
Pre-release documentation updates.

**README.md:**
- Remove Travis CI badge (dead since 2021)
- Update title from "PHP 7" to "PHP"
- Add PHP 8.1+ requirement section
- Add maintenance status note about future Stainless-generated SDK
- Fix API docs link to developers.cloudflare.com
- Remove dead Knowledge Base link
- Clean up stale checklist links

**CHANGELOG.md:**
- New file covering all 2.0.0 changes (breaking: PHP 8.1 minimum, plus dependency upgrades, CI fixes, deprecation fixes)